### PR TITLE
Add more outputs to breaker, allow different ibucket/hybrid outputs

### DIFF
--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
 import argparse
-import dataclasses
 import itertools
 import json
 import multiprocessing
 import random
 import time
-from collections import Counter
 from dataclasses import dataclass
 
 from cpp_boggle import Trie
@@ -16,11 +14,8 @@ from tqdm import tqdm
 from boggle.board_id import from_board_id, is_canonical_board_id
 from boggle.boggler import PyBoggler
 from boggle.breaker import (
-    BreakDetails,
     HybridTreeBreaker,
     IBucketBreaker,
-    merge_details,
-    print_details,
 )
 from boggle.dimensional_bogglers import Bogglers, BucketBogglers, TreeBuilders
 from boggle.eval_tree import EvalTreeBoggler
@@ -46,8 +41,6 @@ def break_init(args):
     (me,) = multiprocessing.current_process()._identity
     with open(f"tasks-{me}.ndjson", "w"):
         pass
-
-    print(f"Started worker #{me}")
 
 
 def break_worker(task: str | int):
@@ -181,11 +174,6 @@ def main():
         help="Breaking strategy to use.",
     )
     parser.add_argument(
-        "--log_per_board_stats",
-        action="store_true",
-        help="Log stats on every board, not just a summary at the end.",
-    )
-    parser.add_argument(
         "--break_class",
         type=str,
         help="Set to a board class to override --random_ids, --max_boards, etc.",
@@ -259,7 +247,7 @@ def main():
     end_s = time.time()
 
     print(f"Broke {len(indices)} classes in {end_s-start_s:.02f}s.")
-    print("All failures:")
+    print(f"Found {len(good_boards)} breaking failure(s):")
     print("\n".join(good_boards))
 
 

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -42,6 +42,7 @@ class IBucketBreakDetails:
 class HybridBreakDetails(IBucketBreakDetails):
     sum_union: int
     bounds: dict[int, int]
+    boards_to_test: int
 
 
 class IBucketBreaker:
@@ -215,6 +216,7 @@ class HybridTreeBreaker:
             secs_by_level=defaultdict(float),
             bounds={},
             sum_union=0,
+            boards_to_test=0,
         )
         self.mark = 1  # New mark for a fresh EvalTree
         self.lifted_cells_ = []
@@ -313,6 +315,7 @@ class HybridTreeBreaker:
         #     for board in boards_to_test:
         #         out.write(f"{board}\n")
 
+        self.details_.boards_to_test = len(boards_to_test)
         start_s = time.time()
         for board in boards_to_test:
             true_score = self.boggler.score(board)

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -52,6 +52,7 @@ class HybridBreakDetails(BreakDetails):
     bounds: dict[int, int]
     boards_to_test: int
     init_nodes: int
+    total_nodes: int
     num_filtered: dict[int, int]
 
 
@@ -227,6 +228,7 @@ class HybridTreeBreaker:
             sum_union=0,
             boards_to_test=0,
             init_nodes=0,
+            total_nodes=0,
             num_filtered={},
         )
         self.mark = 1  # New mark for a fresh EvalTree
@@ -243,6 +245,7 @@ class HybridTreeBreaker:
 
         self.AttackTree(tree, 1, arena)
         self.details_.elapsed_s = time.time() - start_time_s
+        self.details_.total_nodes = arena.num_nodes()
         return self.details_
 
     def pick_cell(self, tree: EvalNode) -> int:

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -44,6 +44,7 @@ class HybridBreakDetails(IBucketBreakDetails):
     bounds: dict[int, int]
     boards_to_test: int
     init_nodes: int
+    num_filtered: dict[int, int]
 
 
 class IBucketBreaker:
@@ -219,6 +220,7 @@ class HybridTreeBreaker:
             sum_union=0,
             boards_to_test=0,
             init_nodes=0,
+            num_filtered={},
         )
         self.mark = 1  # New mark for a fresh EvalTree
         self.lifted_cells_ = []
@@ -271,7 +273,9 @@ class HybridTreeBreaker:
         # ), f"Missed on {level}"
 
         if tree.bound >= self.best_score:
-            tree.filter_below_threshold(self.best_score)
+            n_filtered = tree.filter_below_threshold(self.best_score)
+            if n_filtered:
+                self.details_.num_filtered[level] = n_filtered
             # print(f"f -> {cell=} {tree.bound=}, {tree.unique_node_count()} unique nodes")
         # print(
         #     f"{level=} {cell=} {tree.bound=}, {tree.unique_node_count()} unique nodes"

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -22,24 +22,32 @@ type BucketBoggler = BucketBoggler33 | BucketBoggler34 | BucketBoggler44
 
 
 @dataclass
-class IBucketBreakDetails:
+class BreakDetails:
     num_reps: int
     elapsed_s: float
     failures: list[str]
     elim_level: Counter[int]
-    by_level: Counter[int]
     secs_by_level: defaultdict[int, float]
 
     def asdict(self):
         d = dataclasses.asdict(self)
         d["elim_level"] = dict(self.elim_level.items())
-        d["by_level"] = dict(self.by_level.items())
         d["secs_by_level"] = dict(self.secs_by_level.items())
         return d
 
 
 @dataclass
-class HybridBreakDetails(IBucketBreakDetails):
+class IBucketBreakDetails(BreakDetails):
+    by_level: Counter[int]
+
+    def asdict(self):
+        d = super().asdict()
+        d["by_level"] = dict(self.by_level.items())
+        return d
+
+
+@dataclass
+class HybridBreakDetails(BreakDetails):
     sum_union: int
     bounds: dict[int, int]
     boards_to_test: int
@@ -213,7 +221,6 @@ class HybridTreeBreaker:
             num_reps=0,
             elapsed_s=0.0,
             failures=[],
-            by_level=Counter(),
             elim_level=Counter(),
             secs_by_level=defaultdict(float),
             bounds={},
@@ -284,7 +291,6 @@ class HybridTreeBreaker:
         self.AttackTree(tree, level + 1, arena)
 
     def AttackTree(self, tree: EvalNode, level: int, arena) -> None:
-        self.details_.by_level[level] += 1
         ub = tree.bound
         if ub <= self.best_score:
             # self.elim_ += self.ebb.NumReps()

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -43,6 +43,7 @@ class HybridBreakDetails(IBucketBreakDetails):
     sum_union: int
     bounds: dict[int, int]
     boards_to_test: int
+    init_nodes: int
 
 
 class IBucketBreaker:
@@ -217,6 +218,7 @@ class HybridTreeBreaker:
             bounds={},
             sum_union=0,
             boards_to_test=0,
+            init_nodes=0,
         )
         self.mark = 1  # New mark for a fresh EvalTree
         self.lifted_cells_ = []
@@ -228,6 +230,7 @@ class HybridTreeBreaker:
         self.details_.secs_by_level[0] += time.time() - start_time_s
         self.details_.bounds[0] = tree.bound
         self.details_.sum_union = self.etb.Details().sum_union
+        self.details_.init_nodes = arena.num_nodes()
 
         self.AttackTree(tree, 1, arena)
         self.details_.elapsed_s = time.time() - start_time_s
@@ -313,7 +316,7 @@ class HybridTreeBreaker:
         # print(f"{len(boards_to_test)=}")
         # with open("/tmp/boards-to-test.txt", "w") as out:
         #     for board in boards_to_test:
-        #         out.write(f"{board}\n")
+        #         out.write(f"{board}\n")x
 
         self.details_.boards_to_test = len(boards_to_test)
         start_s = time.time()

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -40,8 +40,8 @@ class IBucketBreakDetails:
 
 @dataclass
 class HybridBreakDetails(IBucketBreakDetails):
-    root_bound: int
     sum_union: int
+    bounds: dict[int, int]
 
 
 class IBucketBreaker:
@@ -213,7 +213,7 @@ class HybridTreeBreaker:
             by_level=Counter(),
             elim_level=Counter(),
             secs_by_level=defaultdict(float),
-            root_bound=0,
+            bounds={},
             sum_union=0,
         )
         self.mark = 1  # New mark for a fresh EvalTree
@@ -224,7 +224,7 @@ class HybridTreeBreaker:
         arena = self.create_arena()
         tree = self.etb.BuildTree(arena, dedupe=True)
         self.details_.secs_by_level[0] += time.time() - start_time_s
-        self.details_.root_bound = tree.bound
+        self.details_.bounds[0] = tree.bound
         self.details_.sum_union = self.etb.Details().sum_union
 
         self.AttackTree(tree, 1, arena)
@@ -251,6 +251,7 @@ class HybridTreeBreaker:
             cell, num_lets, arena, self.mark, dedupe=True, compress=True
         )
         self.details_.secs_by_level[level] += time.time() - start_s
+        self.details_.bounds[level] = tree.bound
         self.lifted_cells_.append(cell)
         # with open(f"/tmp/subtrees-{level}.txt", "w") as out:
         #     for t, seq in tree.max_subtrees():

--- a/boggle/canonicalize.py
+++ b/boggle/canonicalize.py
@@ -4,7 +4,7 @@
 import fileinput
 import math
 
-from symmetry import canonicalize
+from boggle.symmetry import canonicalize
 
 
 def list_to_matrix(letters):

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -420,7 +420,7 @@ class EvalNode:
         self.children = new_children
         return True  # keep
 
-    def filter_below_threshold(self, min_score: int):
+    def filter_below_threshold(self, min_score: int) -> int:
         """Remove choice subtrees with bounds equal to or below min_score.
 
         This operates in-place. It only operates on subtrees that are connected
@@ -430,15 +430,18 @@ class EvalNode:
         # TODO: this would be more efficient to do in force_cell.
         # this could use the caching system, but it's unlikely that the max trees are cached.
         if self.letter != CHOICE_NODE:
-            return
+            return 0
         assert self.bound > min_score
+        n_filtered = 0
         for i, child in enumerate(self.children):
             if not child:
                 continue
             if child.bound <= min_score:
                 self.children[i] = None
+                n_filtered += 1
             else:
-                child.filter_below_threshold(min_score)
+                n_filtered += child.filter_below_threshold(min_score)
+        return n_filtered
 
     def node_count(self):
         return 1 + sum(child.node_count() for child in self.children if child)

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -312,10 +312,11 @@ unsigned int EvalNode::ScoreWithForcesMask(const vector<int>& forces, uint16_t c
   }
 }
 
-void EvalNode::FilterBelowThreshold(int min_score) {
+int EvalNode::FilterBelowThreshold(int min_score) {
   if (letter_ != CHOICE_NODE) {
-    return;
+    return 0;
   }
+  int num_filtered = 0;
   for (int i = 0; i < children_.size(); i++) {
     auto child = children_[i];
     if (!child) {
@@ -323,11 +324,13 @@ void EvalNode::FilterBelowThreshold(int min_score) {
     }
     if (child->bound_ <= min_score) {
       children_[i] = NULL;
+      num_filtered++;
     } else {
       // This casts away the const-ness.
-      ((EvalNode*)child)->FilterBelowThreshold(min_score);
+      num_filtered += ((EvalNode*)child)->FilterBelowThreshold(min_score);
     }
   }
+  return num_filtered;
 }
 
 vector<pair<const EvalNode*, vector<pair<int, int>>>> EvalNode::MaxSubtrees() const {

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -72,7 +72,7 @@ class EvalNode {
   // Must have forces.size() == M * N; set forces[i] = -1 to not force a cell.
   unsigned int ScoreWithForces(const vector<int>& forces) const;
 
-  void FilterBelowThreshold(int min_score);
+  int FilterBelowThreshold(int min_score);
 
   vector<pair<const EvalNode*, vector<pair<int, int>>>> MaxSubtrees() const;
 


### PR DESCRIPTION
This tracks a few more things that are interesting and cheap with the hybrid breaker. I'd like to track the number of calls to score_with_forces at each level, but that seems a little more annoying since it has to cross the Python/C++ barrier.

```
$ poetry run python -m boggle.break_all 'bdfgjvwxz aeiou lnrsy chkmpt' 1600 --size 34 --board_id '1412524, 3183334, 829084, 629591, 23849, 8939131, 1469812, 5907805, 2202513, 6579514' --switchover_level 5 --breaker=hybrid --num_threads 2
$ tail -1 tasks-1.ndjson | jq
```

```json
{
  "num_reps": 949218750,
  "elapsed_s": 2.9155142307281494,
  "failures": [],
  "elim_level": {},
  "secs_by_level": {
    "0": 0.25063133239746094,
    "1": 0.053656816482543945,
    "2": 0.1374671459197998,
    "3": 0.298734188079834,
    "4": 0.5678646564483643,
    "5": 1.5299251079559326,
    "6": 0.0002760887145996094
  },
  "sum_union": 226892,
  "bounds": {
    "0": 51317,
    "1": 34787,
    "2": 20865,
    "3": 13758,
    "4": 8258
  },
  "boards_to_test": 12,
  "init_nodes": 189370,
  "total_nodes": 3535264,
  "num_filtered": {
    "3": 1,
    "4": 36
  },
  "id": 6579514
}
```