### PR TITLE
Use `std::variant` instead of raw pointer math

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,12 +3,14 @@ set -o errexit
 
 cd cpp
 c++ -Wall -shared -std=c++20 -fPIC -march=native \
+    -Wno-sign-compare \
     -O3 \
     $(poetry run python -m pybind11 --includes) \
     cpp_boggle.cc trie.cc eval_node.cc \
     -o ../cpp_boggle$(python3-config --extension-suffix) \
     -undefined dynamic_lookup
 
+# TODO: fix the sign-compare warnings
 # For sampling profiling:
 #     -g
 

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -100,7 +100,7 @@ class EvalNode {
   uint16_t choice_mask_;
 
   mutable uint32_t cache_key_;
-  mutable uintptr_t cache_value_;
+  mutable variant<const EvalNode*, vector<const EvalNode*>*> cache_value_;
 
   mutable uint64_t hash_;
 


### PR DESCRIPTION
This fixes the mysterious segfault in my Docker instance.

It's not really clear to me how this is different than what my code was doing before, but it's certainly cleaner and you can't argue with results!