### PR TITLE
Free before scoring by default

### DIFF
--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -81,6 +81,8 @@ def break_worker(task: str | int):
         summary["id"] = task
         out.write(json.dumps(summary))
         out.write("\n")
+        if args.log_per_board_stats:
+            print(json.dumps(summary, indent=2))
 
     return details.failures
 
@@ -103,7 +105,12 @@ def get_breaker(args) -> BreakingBundle:
 
     if args.breaker == "hybrid":
         breaker = HybridTreeBreaker(
-            etb, boggler, dims, best_score, switchover_level=args.switchover_level
+            etb,
+            boggler,
+            dims,
+            best_score,
+            switchover_level=args.switchover_level,
+            free_after_score=args.free_after_score,
         )
     elif args.breaker == "ibuckets":
         if args.python:
@@ -195,6 +202,17 @@ def main():
         "--resume_from",
         type=str,
         help="Glob pattern of ndjson output files from a previous run.",
+    )
+    parser.add_argument(
+        "--free_after_score",
+        action="store_true",
+        help="Wait to free memory until after score_with_forces in HybridBreaker. "
+        "This is a ~5%% performance hit but significantly reduces the time that memory is held.",
+    )
+    parser.add_argument(
+        "--log_per_board_stats",
+        action="store_true",
+        help="Log stats on every board to stdout, rather just to an ndjson file.",
     )
     parser.add_argument(
         "--python",

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -43,8 +43,8 @@ class PyArena:
     def num_nodes(self):
         return "n/a"
 
-    def mark_and_sweep(self, root):
-        pass
+    def mark_and_sweep(self, root, mark):
+        return 0
 
 
 def create_eval_node_arena_py():

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -608,20 +608,21 @@ void EvalNode::SetChoicePointMask(const vector<int>& num_letters) {
 }
 
 template<typename T>
-void Arena<T>::MarkAndSweep(T* root, uint32_t mark) {
+int Arena<T>::MarkAndSweep(T* root, uint32_t mark) {
   cerr << "MarkAndSweep not implemented" << endl;
   exit(1);
 }
 
 template <>
-void Arena<EvalNode>::MarkAndSweep(EvalNode* root, uint32_t mark) {
+int Arena<EvalNode>::MarkAndSweep(EvalNode* root, uint32_t mark) {
   // Doing this after each LiftChoice() call is a ~10% slowdown.
-  // int num_deleted = 0;
+  root->MarkAllWith(mark);
+  int num_deleted = 0;
   for (auto& node : owned_nodes_) {
     if (node->cache_key_ != mark) {
       delete node;
       node = NULL;
-      // num_deleted++;
+      num_deleted++;
     }
   }
 
@@ -631,6 +632,7 @@ void Arena<EvalNode>::MarkAndSweep(EvalNode* root, uint32_t mark) {
   owned_nodes_.erase(new_end, owned_nodes_.end());
 
   // cout << "Deleted " << num_deleted << " nodes, " << old_size << " -> " << owned_nodes_.size() << endl;
+  return num_deleted;
 }
 
 const EvalNode* merge_trees(const EvalNode* a, const EvalNode* b, EvalNodeArena& arena);

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -44,7 +44,8 @@ class Arena {
     owned_nodes_.push_back(node);
   }
 
-  void MarkAndSweep(T* root, uint32_t mark);
+  // Returns the number of nodes deleted
+  int MarkAndSweep(T* root, uint32_t mark);
 
   // friend EvalNode;
 
@@ -107,6 +108,7 @@ class EvalNode {
   int RecomputeScore() const;
   int NodeCount() const;
   unsigned int UniqueNodeCount(uint32_t mark) const;
+  void MarkAllWith(uint32_t mark);
 
   vector<string> BoundRemainingBoards(
     vector<string> cells,
@@ -117,7 +119,6 @@ class EvalNode {
  private:
   unsigned int ScoreWithForcesMask(const vector<int>& forces, uint16_t choice_mask) const;
   void MaxSubtreesHelp(vector<pair<const EvalNode*, vector<pair<int, int>>>>& out, vector<pair<int, int>> path) const;
-  void MarkAllWith(uint32_t mark);
 };
 
 #endif  // EVAL_NODE_H


### PR DESCRIPTION
I turned off `MarkAndSweep()` before because it was a ~5% performance penalty. But in a world where memory pressure is real, it might be helpful to take some time to free memory before spending 99% of the time in `BoundRemainingBoards()`.

The memory this frees is likely to be highly fragmented, so it may or may not translate to real gains.