### PR TITLE
Letter grouping

### DIFF
--- a/boggle/args.py
+++ b/boggle/args.py
@@ -6,7 +6,7 @@ from cpp_boggle import Trie
 
 from boggle.boggler import PyBoggler
 from boggle.dimensional_bogglers import Bogglers
-from boggle.trie import make_py_trie
+from boggle.trie import get_letter_map, make_py_trie
 
 
 def add_standard_args(
@@ -26,6 +26,14 @@ def add_standard_args(
         help="Path to dictionary file with one word per line. Words must be "
         '"bogglified" via make_boggle_dict.py to convert "qu" -> "q".',
     )
+    parser.add_argument(
+        "--letter_grouping",
+        type=str,
+        default="",
+        help="Letter chunks, space-delimited. The first letter in each chunk is "
+        'the canonical one, so "abc" would change "b" and "c" to "a". Omitted letters '
+        "get their own class. Default is no chunking.",
+    )
 
     if random_seed:
         parser.add_argument(
@@ -44,10 +52,14 @@ def add_standard_args(
 
 def get_trie_from_args(args: argparse.Namespace):
     if args.python:
-        t = make_py_trie(args.dictionary)
+        t = make_py_trie(args.dictionary, args.letter_grouping)
         assert t
     else:
-        t = Trie.CreateFromFile(args.dictionary)
+        if args.letter_grouping:
+            m = get_letter_map(args.letter_grouping)
+            t = Trie.CreateFromFileWithGrouping(args.dictionary, m)
+        else:
+            t = Trie.CreateFromFile(args.dictionary)
         assert t
     return t
 

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -127,11 +127,6 @@ def get_breaker(args) -> BreakingBundle:
     return BreakingBundle(trie=t, etb=etb, boggler=boggler, breaker=breaker)
 
 
-def has_required_class(board: str, required_class: str):
-    cells = board.split(" ")
-    return sum(1 if required_class in cell else 0 for cell in cells) >= 1
-
-
 def main():
     parser = argparse.ArgumentParser(
         description="Find all MxN boggle boards with >=P points",

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -1,14 +1,12 @@
 # Try to speed up ibuckets by explicitly constructing an evaluation tree.
 
 import itertools
-import math
 from collections import Counter
 from typing import Self, Sequence
 
 from boggle.boggler import LETTER_A, LETTER_Q, SCORES
 from boggle.ibuckets import PyBucketBoggler, ScoreDetails
 from boggle.trie import PyTrie, make_lookup_table
-from boggle.util import group_by
 
 ROOT_NODE = -2
 CHOICE_NODE = -1

--- a/boggle/trie.py
+++ b/boggle/trie.py
@@ -90,9 +90,31 @@ def make_lookup_table(t: PyTrie, prefix="", out=None) -> dict[PyTrie, str]:
     return out
 
 
-def make_py_trie(dict_input: str):
+def make_py_trie(dict_input: str, letter_grouping: str):
     t = PyTrie()
+
+    if not letter_grouping:
+        for word in open(dict_input):
+            word = word.strip()
+            t.AddWord(word)
+        return t
+
+    letter_map = get_letter_map(letter_grouping)
     for word in open(dict_input):
         word = word.strip()
-        t.AddWord(word)
+        mapped = "".join(letter_map[c] for c in word)
+        t.AddWord(mapped)
     return t
+
+
+def get_letter_map(letter_grouping: str) -> dict[str, str]:
+    letter_map = {}
+    for chunk in letter_grouping.split(" "):
+        canonical = chunk[0]
+        for alternate in chunk[1:]:
+            letter_map[alternate] = canonical
+    for i in range(26):
+        letter = chr(ord("a") + i)
+        if letter not in letter_map:
+            letter_map[letter] = letter
+    return letter_map

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -85,7 +85,8 @@ PYBIND11_MODULE(cpp_boggle, m)
         .def("NumNodes", &Trie::NumNodes)
         .def("SetAllMarks", &Trie::SetAllMarks)
         .def_static("ReverseLookup", py::overload_cast<const Trie*, const Trie*>(&Trie::ReverseLookup))
-        .def_static("CreateFromFile", &Trie::CreateFromFile);
+        .def_static("CreateFromFile", &Trie::CreateFromFile)
+        .def_static("CreateFromFileWithGrouping", &Trie::CreateFromFileWithGrouping);
 
     declare_boggler<3, 3>(m, "Boggler33");
     declare_boggler<3, 4>(m, "Boggler34");

--- a/cpp/trie.cc
+++ b/cpp/trie.cc
@@ -104,3 +104,23 @@ unique_ptr<Trie> Trie::CreateFromFile(const char* filename) {
 
   return t;
 }
+
+unique_ptr<Trie> Trie::CreateFromFileWithGrouping(const char* filename, unordered_map<char, char> letter_grouping) {
+  char line[80];
+  FILE* f = fopen(filename, "r");
+  if (!f) {
+    fprintf(stderr, "Couldn't open %s\n", filename);
+    return NULL;
+  }
+
+  unique_ptr<Trie> t(new Trie);
+  while (!feof(f) && fscanf(f, "%s", line)) {
+    for (int i = 0; line[i]; i++) {
+      line[i] = letter_grouping[line[i]];
+    }
+    t->AddWord(line);
+  }
+  fclose(f);
+
+  return t;
+}

--- a/cpp/trie.h
+++ b/cpp/trie.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include <sys/types.h>
 #include <stdint.h>
@@ -31,6 +32,7 @@ class Trie {
   // Returns a pointer to the new Trie node at the end of the word.
   Trie* AddWord(const char* wd);
   static unique_ptr<Trie> CreateFromFile(const char* filename);
+  static unique_ptr<Trie> CreateFromFileWithGrouping(const char* filename, unordered_map<char, char> letter_grouping);
 
   // Some slower methods that operate on the entire Trie (not just a node).
   size_t Size();


### PR DESCRIPTION
This is based on JPA's questionable [assertion][1] that there are 14 "qualified" letters. Tossing out half the alphabet does, indeed, result in a profound speedup (something like 10x). But if we're just going to assert that something is true without proof, we may as well assert that the simulated annealing board is globally optimal (which JPA also does!).

It's indisputable that some letters are more valuable than others, though. Looking at Wikipedia's [letter frequency table][2], V, K, X, J, Q, and Z combined occur in fewer words than F or W do. The idea here is to fuse these low-value letters together into "super letters" that are still fairly low-value, but that reduce the combinatorial explosion.

For bookkeeping purposes, "q" has to remain in its own group.

I found this grouping to be conservative but effective: `cz uxj mk wv fb gy`. This gloms "z" and "c" together, "x", "j" and "u" together, etc. This results in a 10-20% speedup and reduces memory usage. Not 10x, but not bad, either. Using a more aggressive grouping (`dz lxj ckv ub mp wy fg`) hurt performance.

The downside is that the score of some boards will be inflated. But not by much, and you can do a second pass to expand them back out. Because max/no-mark already lets you double-count words, you don't need to track collisions in the Trie.

Here's a before/after on a 20 board test set:

- Speed: 117.29 → 97.79s (16.6% faster)
- Memory: 3.76 → 2.42GB (35.7% less)

```
$ /usr/bin/time -l poetry run python -m boggle.break_all 'aeiou bcdfgjmpqvwxz hklnrsty' 1600 --size 34 --breaker=hybrid --switchover_level 5 --board_id '86719, 469, 68981, 102437, 45457, 51621, 29223, 203699, 27916, 32117, 33959, 29836, 293540, 79171, 353, 25692, 34759, 215684, 150385, 11932' --free_after_score
100%|███████████| 20/20 [01:57<00:00,  5.86s/it]
Broke 20 classes in 117.29s.
Found 0 breaking failure(s):

      117.82 real       113.56 user         3.27 sys
          4040392704  maximum resident set size
              601912  page reclaims
                 192  page faults
                 115  voluntary context switches
               45432  involuntary context switches
        796557399629  instructions retired
        394897882107  cycles elapsed
          1729556800  peak memory footprint

/usr/bin/time -l poetry run python -m boggle.break_all  1600 --size 34   5     113.57s user 3.28s system 99% cpu 1:57.83 total

$ /usr/bin/time -l poetry run python -m boggle.break_all 'aeiou cdfgmpqw hlnrst' 1600 --size 34 --breaker=hybrid --switchover_level 5 --board_id '86719, 469, 68981, 102437, 45457, 51621, 29223, 203699, 27916, 32117, 33959, 29836, 293540, 79171, 353, 25692, 34759, 215684, 150385, 11932' --letter_grouping 'cz uxj mk wv fb gy' --free_after_score
100%|███████████| 20/20 [01:37<00:00,  4.89s/it]
Broke 20 classes in 97.79s.
Found 0 breaking failure(s):

       98.32 real        93.51 user         2.44 sys
          2596552704  maximum resident set size
              301484  page reclaims
                 220  page faults
                 124  voluntary context switches
              106262  involuntary context switches
        589606105207  instructions retired
        322262993297  cycles elapsed
           828591488  peak memory footprint
/usr/bin/time -l poetry run python -m boggle.break_all 'aeiou cdfgmpqw hlnrst  93.51s user 2.44s system 97% cpu 1:38.33 total
```

And on just the top-scoring board's class:

- Speed: 278.6 → 160.6s (16.6% faster)
- Memory: 4.35GB → 3.21GB (26% less)

```
$ /usr/bin/time -l poetry run python -m boggle.break_all 'aeiou cdfgmpqw hlnrst' 1600 --size 34 --breaker=hybrid --switchover_level 5 --board_id 234556 --letter_grouping 'cz uxj mk wv fb gy' --free_after_score --log_breaker_progress
root tree.bound=191764, 842018 unique nodes
level=1 cell=5 tree.bound=107586, 1350513 unique nodes
level=2 cell=6 tree.bound=73521, 2413746 unique nodes
level=3 cell=1 tree.bound=42061, 5652320 unique nodes
level=4 cell=9 tree.bound=22596, 12035342 unique nodes
Found 41533 to test.
Unable to break board: dnisetalsref 1675
Unable to break board: dnisetalsrep 1651
Unable to break board: gnisetalsref 1634
Unable to break board: gresenalstif 1643
Unable to break board: gresenalstip 1618
Found unbreakable board for 234556: dnisetalsref
Found unbreakable board for 234556: dnisetalsrep
Found unbreakable board for 234556: gnisetalsref
Found unbreakable board for 234556: gresenalstif
Found unbreakable board for 234556: gresenalstip
Broke 1 classes in 160.60s.
Found 5 breaking failure(s):
dnisetalsref
dnisetalsrep
gnisetalsref
gresenalstif
gresenalstip
      160.99 real       158.89 user         1.23 sys
          3450044416  maximum resident set size
              285127  page reclaims
                 104  page faults
               69552  involuntary context switches
        661809789916  instructions retired
        540713879853  cycles elapsed
          3155818432  peak memory footprint
/usr/bin/time -l poetry run python -m boggle.break_all 'aeiou cdfgmpqw hlnrst  158.90s user 1.24s system 99% cpu 2:41.00 total

$ /usr/bin/time -l poetry run python -m boggle.break_all 'aeiou bcdfgjmpqvwxz hklnrsty' 1600 --size 34 --breaker=hybrid --switchover_level 5 --board_id 234556
Unable to break board: dnisetalsrep 1651
Found unbreakable board for 234556: dnisetalsrep
Broke 1 classes in 278.11s.
Found 1 breaking failure(s):
dnisetalsrep
      278.60 real       276.31 user         1.69 sys
          4674174976  maximum resident set size
              428484  page reclaims
                 220  page faults
                  74  voluntary context switches
               59050  involuntary context switches
       1202915358531  instructions retired
        946028600986  cycles elapsed
          4779985024  peak memory footprint
/usr/bin/time -l poetry run python -m boggle.break_all  1600 --size 34   5    276.32s user 1.70s system 99% cpu 4:38.61 total

```

[1]: https://web.archive.org/web/20101207194405/http://www.pathcom.com/~vadco/deep.html#:~:text=thread%2C%20per%20round.-,The,-lexicon%20and%20character
[2]: https://en.wikipedia.org/wiki/Letter_frequency#Relative_frequencies_of_letters_in_other_languages