### PR TITLE
Orderly trees

### DIFF
--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -15,6 +15,7 @@ from boggle.eval_tree import (
     EvalNode,
     EvalTreeBoggler,
 )
+from boggle.split_order import SPLIT_ORDER
 
 type BucketBoggler = BucketBoggler33 | BucketBoggler34 | BucketBoggler44
 
@@ -425,61 +426,3 @@ def merge_details(
         ),
         # root_score_bailout=None,
     )
-
-
-SPLIT_ORDER_33 = (4, 5, 3, 1, 7, 0, 2, 6, 8)
-
-
-def to_idx(x, y):
-    return x * 4 + y
-
-
-SPLIT_ORDER_34 = tuple(
-    to_idx(x, y)
-    for x, y in (
-        (1, 1),
-        (1, 2),  # middle
-        (0, 1),
-        (2, 1),
-        (0, 2),
-        (2, 2),  # middle sides
-        (1, 0),
-        (1, 3),  # top/bottom middle
-        (0, 0),
-        (2, 0),
-        (0, 3),
-        (2, 3),  # corners
-    )
-)
-assert len(SPLIT_ORDER_34) == 12
-
-SPLIT_ORDER_44 = tuple(
-    to_idx(x, y)
-    for x, y in (
-        (1, 1),
-        (1, 2),
-        (2, 1),
-        (2, 2),  # middle
-        (0, 1),
-        (3, 1),
-        (0, 2),
-        (3, 2),  # middle sides
-        (1, 0),
-        (1, 3),
-        (2, 0),
-        (2, 3),  # top/bottom middle
-        (0, 0),
-        (3, 0),
-        (0, 3),
-        (3, 3),  # corners
-    )
-)
-assert len(SPLIT_ORDER_44) == 16
-assert len(set(SPLIT_ORDER_44)) == 16
-
-SPLIT_ORDER = {
-    (2, 2): (0, 1, 2, 3),
-    (3, 3): SPLIT_ORDER_33,
-    (3, 4): SPLIT_ORDER_34,
-    (4, 4): SPLIT_ORDER_44,
-}

--- a/boggle/dimensional_bogglers.py
+++ b/boggle/dimensional_bogglers.py
@@ -6,6 +6,10 @@ from cpp_boggle import (
     BucketBoggler33,
     BucketBoggler34,
     BucketBoggler44,
+    OrderlyTreeBuilder22,
+    OrderlyTreeBuilder33,
+    OrderlyTreeBuilder34,
+    OrderlyTreeBuilder44,
     TreeBuilder22,
     TreeBuilder33,
     TreeBuilder34,
@@ -29,6 +33,13 @@ TreeBuilders = {
     (3, 3): TreeBuilder33,
     (3, 4): TreeBuilder34,
     (4, 4): TreeBuilder44,
+}
+
+OrderlyTreeBuilders = {
+    (2, 2): OrderlyTreeBuilder22,
+    (3, 3): OrderlyTreeBuilder33,
+    (3, 4): OrderlyTreeBuilder34,
+    (4, 4): OrderlyTreeBuilder44,
 }
 
 

--- a/boggle/dimensional_bogglers.py
+++ b/boggle/dimensional_bogglers.py
@@ -53,6 +53,10 @@ def cpp_tree_builder(t, dims):
     return TreeBuilders[dims](t)
 
 
+def cpp_orderly_tree_builder(t, dims):
+    return OrderlyTreeBuilders[dims](t)
+
+
 LEN_TO_DIMS = {
     4: (2, 2),
     6: (2, 3),

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -44,6 +44,9 @@ class PyArena:
     def mark_and_sweep(self, root, mark):
         return 0
 
+    def new_node(self):
+        return EvalNode()
+
 
 def create_eval_node_arena_py():
     return PyArena()
@@ -73,7 +76,7 @@ class EvalNode:
         self.cache_key = None
         self.cache_value = None
 
-    def add_word(self, choices: Sequence[tuple[int, int]], points: int):
+    def add_word(self, choices: Sequence[tuple[int, int]], points: int, arena):
         """Add a word at the end of a sequence of choices to the tree.
 
         This doesn't update bounds or choice_mask.
@@ -85,6 +88,8 @@ class EvalNode:
 
         (cell, letter) = choices[0]
         remaining_choices = choices[1:]
+
+        # TODO: binary search
         choice_child = None
         for c in self.children:
             if c.cell == cell:
@@ -97,6 +102,7 @@ class EvalNode:
             self.children.append(choice_child)
             # TODO: could keep self.children sorted
 
+        # TODO: binary search
         letter_child = None
         for c in choice_child.children:
             if c.letter == letter:
@@ -106,10 +112,11 @@ class EvalNode:
             letter_child = EvalNode()
             letter_child.cell = cell
             letter_child.letter = letter
+            # TODO: this could be more efficient
             choice_child.children.append(letter_child)
             choice_child.children.sort(key=lambda c: c.letter)
 
-        letter_child.add_word(remaining_choices, points)
+        letter_child.add_word(remaining_choices, points, arena)
 
     def recompute_score(self):
         # Should return self.bound

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -778,13 +778,13 @@ class EvalNode:
             )
         return results
 
-    def set_computed_fields(self, cells: Sequence[str]):
+    def set_computed_fields(self, num_letters: Sequence[int]):
         for c in self.children:
             if c:
-                c.set_computed_fields(cells)
+                c.set_computed_fields(num_letters)
 
         if self.letter == CHOICE_NODE:
-            self.choice_mask = 1 << self.cell if len(cells[self.cell]) > 1 else 0
+            self.choice_mask = 1 << self.cell if num_letters[self.cell] > 1 else 0
             self.bound = (
                 max(c.bound for c in self.children if c) if self.children else 0
             )

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -45,7 +45,10 @@ class PyArena:
         return 0
 
     def new_node(self):
-        return EvalNode()
+        n = EvalNode()
+        n.letter = ROOT_NODE
+        n.cell = 0
+        return n
 
 
 def create_eval_node_arena_py():
@@ -775,10 +778,10 @@ class EvalNode:
             )
         return results
 
-    def set_computed_fields_for_testing(self, cells: Sequence[str]):
+    def set_computed_fields(self, cells: Sequence[str]):
         for c in self.children:
             if c:
-                c.set_computed_fields_for_testing(cells)
+                c.set_computed_fields(cells)
 
         if self.letter == CHOICE_NODE:
             self.choice_mask = 1 << self.cell if len(cells[self.cell]) > 1 else 0

--- a/boggle/eval_tree_test.py
+++ b/boggle/eval_tree_test.py
@@ -791,6 +791,7 @@ def test_lift_invariants_33(make_trie, get_tree_builder, create_arena):
 
 def test_lift_sum():
     cells = ["ab", "xy"]
+    num_letters = [len(cell) for cell in cells]
     root = letter_node(
         cell=0,
         letter=ROOT_NODE,
@@ -811,7 +812,7 @@ def test_lift_sum():
             ),
         ],
     )
-    root.set_computed_fields(cells)
+    root.set_computed_fields(num_letters)
     # print(root.to_dot(cells))
 
     assert root.choice_mask == 0b11
@@ -839,6 +840,7 @@ def test_lift_sum():
 
 def test_lift_choice():
     cells = ["abc", "xy"]
+    num_letters = [len(cell) for cell in cells]
     root = choice_node(
         cell=0,
         children=[
@@ -867,7 +869,7 @@ def test_lift_choice():
             ),
         ],
     )
-    root.set_computed_fields(cells)
+    root.set_computed_fields(num_letters)
     # print(root.to_dot(cells))
     assert root.bound == 4
 
@@ -882,6 +884,7 @@ def test_lift_choice():
 
 def test_merge_choice_trees():
     cells = ["abc"]
+    num_letters = [len(cell) for cell in cells]
     root = letter_node(
         cell=0,
         letter=ROOT_NODE,
@@ -902,7 +905,7 @@ def test_merge_choice_trees():
             ),
         ],
     )
-    root.set_computed_fields(cells)
+    root.set_computed_fields(num_letters)
     assert root.bound == 6
     # print(root.to_dot(cells))
     # print("---")
@@ -927,6 +930,7 @@ def test_squeeze_sum():
 
 def test_squeeze_sum_with_duplicate_choices():
     cells = ["abc", "de", "fg", "h"]
+    num_letters = [len(cell) for cell in cells]
     root = letter_node(
         cell=3,
         letter=ROOT_NODE,
@@ -968,7 +972,7 @@ def test_squeeze_sum_with_duplicate_choices():
             ),
         ],
     )
-    root.set_computed_fields(cells)
+    root.set_computed_fields(num_letters)
     assert len(root.children) == 5
 
     # print(root.to_dot(cells))
@@ -986,6 +990,7 @@ def test_add_word(create_arena):
     arena = create_arena()
     root = arena.new_node()
     cells = ["bcd", "aei", "nrd"]
+    num_letters = [len(cell) for cell in cells]
     root.add_word([(0, 0), (1, 0), (2, 0)], 1, arena)  # ban
     root.add_word([(0, 1), (1, 0), (2, 0)], 1, arena)  # can
     root.add_word([(0, 0), (1, 0), (2, 1)], 1, arena)  # bar
@@ -993,8 +998,7 @@ def test_add_word(create_arena):
     root.add_word([(0, 0), (1, 2), (2, 2)], 1, arena)  # bid
     root.add_word([(0, 2), (1, 2), (2, 2)], 1, arena)  # did
 
-    # XXX maybe not just for testing any more!
-    root.set_computed_fields(cells)
+    root.set_computed_fields(num_letters)
 
     # print(root.to_dot(cells))
 

--- a/boggle/eval_tree_test.py
+++ b/boggle/eval_tree_test.py
@@ -979,9 +979,15 @@ def test_squeeze_sum_with_duplicate_choices():
     assert len(root.children) == 3
 
 
+# @pytest.mark.parametrize(
+#     "create_arena", (create_eval_node_arena_py, create_eval_node_arena)
+# )
 def test_add_word():
-    arena = create_eval_node_arena_py()
-    root = letter_node(cell=0, letter=ROOT_NODE)
+    create_arena = create_eval_node_arena_py
+    arena = create_arena()
+    root = arena.new_node()
+    root.cell = 0
+    root.letter = ROOT_NODE
     cells = ["bcd", "aei", "nrd"]
     root.add_word([(0, 0), (1, 0), (2, 0)], 1, arena)  # ban
     root.add_word([(0, 1), (1, 0), (2, 0)], 1, arena)  # can

--- a/boggle/eval_tree_test.py
+++ b/boggle/eval_tree_test.py
@@ -811,7 +811,7 @@ def test_lift_sum():
             ),
         ],
     )
-    root.set_computed_fields_for_testing(cells)
+    root.set_computed_fields(cells)
     # print(root.to_dot(cells))
 
     assert root.choice_mask == 0b11
@@ -867,7 +867,7 @@ def test_lift_choice():
             ),
         ],
     )
-    root.set_computed_fields_for_testing(cells)
+    root.set_computed_fields(cells)
     # print(root.to_dot(cells))
     assert root.bound == 4
 
@@ -902,7 +902,7 @@ def test_merge_choice_trees():
             ),
         ],
     )
-    root.set_computed_fields_for_testing(cells)
+    root.set_computed_fields(cells)
     assert root.bound == 6
     # print(root.to_dot(cells))
     # print("---")
@@ -968,7 +968,7 @@ def test_squeeze_sum_with_duplicate_choices():
             ),
         ],
     )
-    root.set_computed_fields_for_testing(cells)
+    root.set_computed_fields(cells)
     assert len(root.children) == 5
 
     # print(root.to_dot(cells))
@@ -979,15 +979,12 @@ def test_squeeze_sum_with_duplicate_choices():
     assert len(root.children) == 3
 
 
-# @pytest.mark.parametrize(
-#     "create_arena", (create_eval_node_arena_py, create_eval_node_arena)
-# )
-def test_add_word():
-    create_arena = create_eval_node_arena_py
+@pytest.mark.parametrize(
+    "create_arena", (create_eval_node_arena_py, create_eval_node_arena)
+)
+def test_add_word(create_arena):
     arena = create_arena()
     root = arena.new_node()
-    root.cell = 0
-    root.letter = ROOT_NODE
     cells = ["bcd", "aei", "nrd"]
     root.add_word([(0, 0), (1, 0), (2, 0)], 1, arena)  # ban
     root.add_word([(0, 1), (1, 0), (2, 0)], 1, arena)  # can
@@ -997,7 +994,7 @@ def test_add_word():
     root.add_word([(0, 2), (1, 2), (2, 2)], 1, arena)  # did
 
     # XXX maybe not just for testing any more!
-    root.set_computed_fields_for_testing(cells)
+    root.set_computed_fields(cells)
 
     # print(root.to_dot(cells))
 
@@ -1006,4 +1003,9 @@ def test_add_word():
         with open("testdata/add_word.txt", "w") as out:
             out.write(eval_node_to_string(root, cells))
     # This asserts that the C++ and Python trees stay in sync
-    assert eval_node_to_string(root, cells) == open("testdata/add_word.txt").read()
+    expected = open("testdata/add_word.txt").read()
+    actual = eval_node_to_string(root, cells)
+    if actual != expected:
+        with open("/tmp/actual.txt", "w") as out:
+            out.write(actual)
+        assert actual == expected

--- a/boggle/eval_tree_test.py
+++ b/boggle/eval_tree_test.py
@@ -662,20 +662,20 @@ def test_lift_invariants_22():
 
 
 INVARIANT_PARAMS = [
-    (make_py_trie, EvalTreeBoggler, create_eval_node_arena_py),
-    (Trie.CreateFromFile, cpp_tree_builder, create_eval_node_arena),
+    (make_py_trie, EvalTreeBoggler),
+    (Trie.CreateFromFile, cpp_tree_builder),
 ]
 
 
-@pytest.mark.parametrize("make_trie, get_tree_builder, create_arena", INVARIANT_PARAMS)
-def test_lift_invariants_22_equivalent(make_trie, get_tree_builder, create_arena):
+@pytest.mark.parametrize("make_trie, get_tree_builder", INVARIANT_PARAMS)
+def test_lift_invariants_22_equivalent(make_trie, get_tree_builder):
     trie = make_trie("testdata/boggle-words-4.txt")
     board = "ny ae ch ."
     cells = board.split(" ")
     num_letters = [len(c) for c in cells]
     etb = get_tree_builder(trie, (2, 2))
     etb.ParseBoard(board)
-    arena = create_arena()
+    arena = etb.create_arena()
     t = etb.BuildTree(arena)
     if isinstance(t, EvalNode):
         t.assert_invariants(etb)
@@ -708,15 +708,15 @@ def test_lift_invariants_22_equivalent(make_trie, get_tree_builder, create_arena
 WRITE_SNAPSHOTS = False
 
 
-@pytest.mark.parametrize("make_trie, get_tree_builder, create_arena", INVARIANT_PARAMS)
-def test_lift_invariants_33(make_trie, get_tree_builder, create_arena):
+@pytest.mark.parametrize("make_trie, get_tree_builder", INVARIANT_PARAMS)
+def test_lift_invariants_33(make_trie, get_tree_builder):
     trie = make_trie("testdata/boggle-words-9.txt")
     board = ". . . . lnrsy e aeiou aeiou ."
     # board = ". . . . nr e ai au ."
     cells = board.split(" ")
     etb = get_tree_builder(trie, dims=(3, 3))
     etb.ParseBoard(board)
-    arena = create_arena()
+    arena = etb.create_arena()
     # t = etb.BuildTree(arena, dedupe=True)
     t = etb.BuildTree(arena)
     if isinstance(t, EvalNode):

--- a/boggle/eval_tree_test.py
+++ b/boggle/eval_tree_test.py
@@ -976,3 +976,20 @@ def test_squeeze_sum_with_duplicate_choices():
     squeeze_sum_node_in_place(root, True)
     # print(root.to_dot(cells))
     assert len(root.children) == 3
+
+
+def test_add_word():
+    root = letter_node(cell=0, letter=ROOT_NODE)
+    cells = ["bcd", "aei", "nrd"]
+    root.add_word([(0, 0), (1, 0), (2, 0)], 1)  # ban
+    root.add_word([(0, 1), (1, 0), (2, 0)], 1)  # can
+    root.add_word([(0, 0), (1, 0), (2, 1)], 1)  # bar
+    root.add_word([(0, 0), (1, 1), (2, 2)], 1)  # bed
+    root.add_word([(0, 0), (1, 2), (2, 2)], 1)  # bid
+    root.add_word([(0, 2), (1, 2), (2, 2)], 1)  # did
+
+    # XXX maybe not just for testing any more!
+    root.set_computed_fields_for_testing(cells)
+
+    print(root.to_dot(cells))
+    assert False

--- a/boggle/eval_tree_test.py
+++ b/boggle/eval_tree_test.py
@@ -704,6 +704,7 @@ def test_lift_invariants_22_equivalent(make_trie, get_tree_builder, create_arena
             tl.assert_invariants(etb)
 
 
+# TODO: set up a real snapshot tool
 WRITE_SNAPSHOTS = False
 
 
@@ -979,17 +980,24 @@ def test_squeeze_sum_with_duplicate_choices():
 
 
 def test_add_word():
+    arena = create_eval_node_arena_py()
     root = letter_node(cell=0, letter=ROOT_NODE)
     cells = ["bcd", "aei", "nrd"]
-    root.add_word([(0, 0), (1, 0), (2, 0)], 1)  # ban
-    root.add_word([(0, 1), (1, 0), (2, 0)], 1)  # can
-    root.add_word([(0, 0), (1, 0), (2, 1)], 1)  # bar
-    root.add_word([(0, 0), (1, 1), (2, 2)], 1)  # bed
-    root.add_word([(0, 0), (1, 2), (2, 2)], 1)  # bid
-    root.add_word([(0, 2), (1, 2), (2, 2)], 1)  # did
+    root.add_word([(0, 0), (1, 0), (2, 0)], 1, arena)  # ban
+    root.add_word([(0, 1), (1, 0), (2, 0)], 1, arena)  # can
+    root.add_word([(0, 0), (1, 0), (2, 1)], 1, arena)  # bar
+    root.add_word([(0, 0), (1, 1), (2, 2)], 1, arena)  # bed
+    root.add_word([(0, 0), (1, 2), (2, 2)], 1, arena)  # bid
+    root.add_word([(0, 2), (1, 2), (2, 2)], 1, arena)  # did
 
     # XXX maybe not just for testing any more!
     root.set_computed_fields_for_testing(cells)
 
-    print(root.to_dot(cells))
-    assert False
+    # print(root.to_dot(cells))
+
+    is_python = isinstance(root, EvalNode)
+    if WRITE_SNAPSHOTS and is_python:
+        with open("testdata/add_word.txt", "w") as out:
+            out.write(eval_node_to_string(root, cells))
+    # This asserts that the C++ and Python trees stay in sync
+    assert eval_node_to_string(root, cells) == open("testdata/add_word.txt").read()

--- a/boggle/lift_22.py
+++ b/boggle/lift_22.py
@@ -53,7 +53,7 @@ def main():
         etb = cpp_tree_builder(trie, dims)
 
     arena = etb.create_arena()
-    etb.ParseBoard(board)
+    assert etb.ParseBoard(board)
     t = etb.BuildTree(arena, dedupe=args.dedupe)
     print(tree_stats(t))
     # t.compress_in_place()

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -2,7 +2,7 @@ import argparse
 
 from boggle.args import add_standard_args, get_trie_from_args
 from boggle.boggler import LETTER_A, LETTER_Q, SCORES
-from boggle.dimensional_bogglers import LEN_TO_DIMS
+from boggle.dimensional_bogglers import LEN_TO_DIMS, OrderlyTreeBuilders
 from boggle.eval_tree import (
     ROOT_NODE,
     EvalNode,
@@ -105,7 +105,8 @@ def main():
     # e_arena = etb.create_arena()
     # classic_tree = etb.BuildTree(e_arena, dedupe=True)
 
-    otb = OrderlyTreeBuilder(trie, dims)
+    # otb = OrderlyTreeBuilder(trie, dims)
+    otb = OrderlyTreeBuilders[dims](trie)
     o_arena = otb.create_arena()
     assert otb.ParseBoard(board)
     orderly_tree = otb.BuildTree(o_arena)

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -36,7 +36,7 @@ class OrderlyTreeBuilder(PyBucketBoggler):
 
         for cell in range(len(self.bd_)):
             self.DoAllDescents(cell, 0, self.trie_, [])
-        root.set_computed_fields_for_testing(self.bd_)
+        root.set_computed_fields(self.bd_)
         self.root = None
         return root
 

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -36,7 +36,8 @@ class OrderlyTreeBuilder(PyBucketBoggler):
 
         for cell in range(len(self.bd_)):
             self.DoAllDescents(cell, 0, self.trie_, [])
-        root.set_computed_fields(self.bd_)
+        num_letters = [len(cell) for cell in self.bd_]
+        root.set_computed_fields(num_letters)
         self.root = None
         return root
 

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -1,0 +1,120 @@
+import argparse
+
+from boggle.args import add_standard_args, get_trie_from_args
+from boggle.boggler import LETTER_A, LETTER_Q, SCORES
+from boggle.dimensional_bogglers import LEN_TO_DIMS
+from boggle.eval_tree import (
+    ROOT_NODE,
+    EvalNode,
+    EvalTreeBoggler,
+    create_eval_node_arena_py,
+)
+from boggle.ibuckets import PyBucketBoggler
+from boggle.split_order import SPLIT_ORDER
+from boggle.trie import PyTrie
+
+
+# TODO: decide if this really needs to inherit PyBucketBoggler
+class OrderlyTreeBuilder(PyBucketBoggler):
+    cell_to_order: dict[int, int]
+    root: EvalNode
+
+    def __init__(self, trie: PyTrie, dims: tuple[int, int] = (3, 3)):
+        super().__init__(trie, dims)
+        self.cell_to_order = {cell: i for i, cell in enumerate(SPLIT_ORDER[dims])}
+
+    def UpperBound(self, bailout_score):
+        raise NotImplementedError()
+
+    def BuildTree(self, arena=None):
+        root = EvalNode()
+        root.letter = ROOT_NODE
+        root.cell = 0  # irrelevant
+        root.points = 0
+        self.root = root
+        self.used_ = 0
+
+        for cell in range(len(self.bd_)):
+            self.DoAllDescents(cell, 0, self.trie_, [])
+        root.set_computed_fields_for_testing(self.bd_)
+        self.root = None
+        return root
+
+    # TODO: rename these methods
+    def DoAllDescents(
+        self, cell: int, length: int, t: PyTrie, choices: list[tuple[int, int]]
+    ):
+        choices.append((cell, 0))
+        for j, char in enumerate(self.bd_[cell]):
+            cc = ord(char) - LETTER_A
+            if t.StartsWord(cc):
+                choices[-1] = (cell, j)
+                self.DoDFS(
+                    cell, length + (2 if cc == LETTER_Q else 1), t.Descend(cc), choices
+                )
+        choices.pop()
+
+    def DoDFS(
+        self,
+        cell: int,
+        length: int,
+        t: PyTrie,
+        choices: list[tuple[int, int]],
+    ):
+        self.used_ ^= 1 << cell
+
+        for idx in self.neighbors[cell]:
+            if not self.used_ & (1 << idx):
+                self.DoAllDescents(idx, length, t, choices)
+
+        if t.IsWord():
+            word_score = SCORES[length]
+            # TODO: sort by split order
+            orderly_choices = [*sorted(choices, key=lambda c: self.cell_to_order[c[0]])]
+            self.root.add_word(orderly_choices, word_score)
+
+        self.used_ ^= 1 << cell
+
+    def create_arena(self):
+        return create_eval_node_arena_py()
+
+
+mark = 1
+
+
+def tree_stats(t: EvalNode) -> str:
+    global mark
+    mark += 1
+    return f"{t.bound=}, {t.node_count()} nodes, {t.unique_node_count(mark)} unique"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Lift all the way to breaking")
+    add_standard_args(parser, python=True)
+    parser.add_argument("board", type=str, help="Board class to lift.")
+    args = parser.parse_args()
+    board = args.board
+    cells = board.split(" ")
+    dims = LEN_TO_DIMS[len(cells)]
+    trie = get_trie_from_args(args)
+    etb = EvalTreeBoggler(trie, dims)
+    assert etb.ParseBoard(board)
+    e_arena = etb.create_arena()
+    classic_tree = etb.BuildTree(e_arena, dedupe=True)
+
+    otb = OrderlyTreeBuilder(trie, dims)
+    o_arena = otb.create_arena()
+    assert otb.ParseBoard(board)
+    orderly_tree = otb.BuildTree(o_arena)
+
+    print(orderly_tree.to_dot(cells))
+
+    print("EvalTreeBuilder:")
+    print(tree_stats(classic_tree))
+
+    print("OrderlyTreeBuilder:")
+    print(tree_stats(orderly_tree))
+
+
+if __name__ == "__main__":
+    main()

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -107,12 +107,10 @@ def main():
     assert otb.ParseBoard(board)
     orderly_tree = otb.BuildTree(o_arena)
 
-    print(orderly_tree.to_dot(cells))
-
-    print("EvalTreeBuilder:")
+    print("EvalTreeBuilder:    ", end="")
     print(tree_stats(classic_tree))
 
-    print("OrderlyTreeBuilder:")
+    print("OrderlyTreeBuilder: ", end="")
     print(tree_stats(orderly_tree))
 
 

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -4,7 +4,7 @@ from cpp_boggle import Trie
 from boggle.dimensional_bogglers import cpp_orderly_tree_builder
 from boggle.eval_tree import EvalNode, eval_node_to_string
 from boggle.orderly_tree_builder import OrderlyTreeBuilder
-from boggle.trie import PyTrie
+from boggle.trie import PyTrie, make_py_trie
 
 WRITE_SNAPSHOTS = False
 
@@ -44,5 +44,33 @@ def test_build_orderly_tree(TrieT, TreeBuilderT):
     snapshot(
         eval_node_to_string(t, cells),
         "testdata/sepeathtc-tree.txt",
+        is_readonly=is_readonly,
+    )
+
+
+@pytest.mark.parametrize(
+    "make_trie, get_tree_builder",
+    [
+        (make_py_trie, OrderlyTreeBuilder),
+        (Trie.CreateFromFile, cpp_orderly_tree_builder),
+    ],
+)
+def test_lift_invariants_33(make_trie, get_tree_builder):
+    trie = make_trie("testdata/boggle-words-9.txt")
+    board = ". . . . lnrsy e aeiou aeiou ."
+    # board = ". . . . nr e ai au ."
+    cells = board.split(" ")
+    otb = get_tree_builder(trie, dims=(3, 3))
+    otb.ParseBoard(board)
+    arena = otb.create_arena()
+    t = otb.BuildTree(arena)
+    if isinstance(t, EvalNode):
+        t.assert_invariants(otb)
+
+    is_python = isinstance(t, EvalNode)
+    is_readonly = not is_python
+    snapshot(
+        eval_node_to_string(t, cells),
+        "testdata/orderly-3x3.txt",
         is_readonly=is_readonly,
     )

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -1,0 +1,36 @@
+from boggle.eval_tree import EvalNode
+from boggle.orderly_tree_builder import OrderlyTreeBuilder
+from boggle.trie import PyTrie
+
+WRITE_SNAPSHOTS = False
+
+
+def snapshot(value: str, filename: str, is_readonly=False):
+    if WRITE_SNAPSHOTS and not is_readonly:
+        with open(filename, "w") as out:
+            out.write(value)
+    expected = open(filename).read()
+    assert value == expected
+
+
+def test_build_orderly_tree():
+    t = PyTrie()
+    t.AddWord("sea")
+    t.AddWord("seat")
+    t.AddWord("seats")
+    t.AddWord("tea")
+    t.AddWord("teas")
+
+    bb = OrderlyTreeBuilder(t, (3, 3))
+    arena = bb.create_arena()
+
+    # s e h
+    # e a t
+    # p u c
+    board = "s e p e a u h t c"
+    cells = board.split(" ")
+    assert bb.ParseBoard(board)
+    t = bb.BuildTree(arena)
+    is_python = isinstance(t, EvalNode)
+    is_readonly = not is_python
+    snapshot(t.to_string(cells), "testdata/sepeathtc-tree.txt", is_readonly=is_readonly)

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -1,4 +1,8 @@
-from boggle.eval_tree import EvalNode
+import pytest
+from cpp_boggle import Trie
+
+from boggle.dimensional_bogglers import cpp_orderly_tree_builder
+from boggle.eval_tree import EvalNode, eval_node_to_string
 from boggle.orderly_tree_builder import OrderlyTreeBuilder
 from boggle.trie import PyTrie
 
@@ -13,15 +17,19 @@ def snapshot(value: str, filename: str, is_readonly=False):
     assert value == expected
 
 
-def test_build_orderly_tree():
-    t = PyTrie()
+@pytest.mark.parametrize(
+    "TrieT, TreeBuilderT",
+    [(PyTrie, OrderlyTreeBuilder), (Trie, cpp_orderly_tree_builder)],
+)
+def test_build_orderly_tree(TrieT, TreeBuilderT):
+    t = TrieT()
     t.AddWord("sea")
     t.AddWord("seat")
     t.AddWord("seats")
     t.AddWord("tea")
     t.AddWord("teas")
 
-    bb = OrderlyTreeBuilder(t, (3, 3))
+    bb = TreeBuilderT(t, (3, 3))
     arena = bb.create_arena()
 
     # s e h
@@ -33,4 +41,8 @@ def test_build_orderly_tree():
     t = bb.BuildTree(arena)
     is_python = isinstance(t, EvalNode)
     is_readonly = not is_python
-    snapshot(t.to_string(cells), "testdata/sepeathtc-tree.txt", is_readonly=is_readonly)
+    snapshot(
+        eval_node_to_string(t, cells),
+        "testdata/sepeathtc-tree.txt",
+        is_readonly=is_readonly,
+    )

--- a/boggle/split_order.py
+++ b/boggle/split_order.py
@@ -1,0 +1,58 @@
+"""Order in which to split cells. Middle then edges then corners."""
+
+SPLIT_ORDER_33 = (4, 5, 3, 1, 7, 0, 2, 6, 8)
+
+
+def to_idx(x, y):
+    return x * 4 + y
+
+
+SPLIT_ORDER_34 = tuple(
+    to_idx(x, y)
+    for x, y in (
+        (1, 1),
+        (1, 2),  # middle
+        (0, 1),
+        (2, 1),
+        (0, 2),
+        (2, 2),  # middle sides
+        (1, 0),
+        (1, 3),  # top/bottom middle
+        (0, 0),
+        (2, 0),
+        (0, 3),
+        (2, 3),  # corners
+    )
+)
+assert len(SPLIT_ORDER_34) == 12
+
+SPLIT_ORDER_44 = tuple(
+    to_idx(x, y)
+    for x, y in (
+        (1, 1),
+        (1, 2),
+        (2, 1),
+        (2, 2),  # middle
+        (0, 1),
+        (3, 1),
+        (0, 2),
+        (3, 2),  # middle sides
+        (1, 0),
+        (1, 3),
+        (2, 0),
+        (2, 3),  # top/bottom middle
+        (0, 0),
+        (3, 0),
+        (0, 3),
+        (3, 3),  # corners
+    )
+)
+assert len(SPLIT_ORDER_44) == 16
+assert len(set(SPLIT_ORDER_44)) == 16
+
+SPLIT_ORDER = {
+    (2, 2): (0, 1, 2, 3),
+    (3, 3): SPLIT_ORDER_33,
+    (3, 4): SPLIT_ORDER_34,
+    (4, 4): SPLIT_ORDER_44,
+}

--- a/boggle/split_order.py
+++ b/boggle/split_order.py
@@ -1,5 +1,7 @@
 """Order in which to split cells. Middle then edges then corners."""
 
+import json
+
 SPLIT_ORDER_33 = (4, 5, 3, 1, 7, 0, 2, 6, 8)
 
 
@@ -56,3 +58,17 @@ SPLIT_ORDER = {
     (3, 4): SPLIT_ORDER_34,
     (4, 4): SPLIT_ORDER_44,
 }
+
+
+def main():
+    for (w, h), split_order in SPLIT_ORDER.items():
+        print(
+            f"""template<>
+const int BucketBoggler<{w}, {h}>::SPLIT_ORDER[{w}*{h}] = {{%s}};
+"""
+            % ", ".join(str(x) for x in split_order)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -119,6 +119,7 @@ PYBIND11_MODULE(cpp_boggle, m)
         .def("node_count", &EvalNode::NodeCount)
         .def("unique_node_count", &EvalNode::UniqueNodeCount)
         .def("add_word", &EvalNode::AddWord)
+        .def("set_computed_fields", &EvalNode::SetComputedFields)
         // TODO: remove this
         .def(
             "force_cell",

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -125,10 +125,10 @@ PYBIND11_MODULE(cpp_boggle, m)
     declare_tree_builder<3, 4>(m, "TreeBuilder34");
     declare_tree_builder<4, 4>(m, "TreeBuilder44");
 
-    declare_orderly_tree_builder<2, 2>(m, "TreeBuilder22");
-    // declare_orderly_tree_builder<3, 3>(m, "TreeBuilder33");
-    // declare_orderly_tree_builder<3, 4>(m, "TreeBuilder34");
-    // declare_orderly_tree_builder<4, 4>(m, "TreeBuilder44");
+    declare_orderly_tree_builder<2, 2>(m, "OrderlyTreeBuilder22");
+    declare_orderly_tree_builder<3, 3>(m, "OrderlyTreeBuilder33");
+    declare_orderly_tree_builder<3, 4>(m, "OrderlyTreeBuilder34");
+    declare_orderly_tree_builder<4, 4>(m, "OrderlyTreeBuilder44");
 
     py::class_<ScoreDetails>(m, "ScoreDetails", py::buffer_protocol())
         .def_readwrite("max_nomark", &ScoreDetails::max_nomark)

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -11,6 +11,7 @@ using std::vector;
 #include "ibuckets.h"
 #include "eval_node.h"
 #include "tree_builder.h"
+#include "orderly_tree_builder.h"
 // #include "breaker.h"
 
 // See https://stackoverflow.com/a/47749076/388951
@@ -32,6 +33,28 @@ void declare_bucket_boggler(py::module &m, const string &pyclass_name) {
 template<int M, int N>
 void declare_tree_builder(py::module &m, const string &pyclass_name) {
     using BB = TreeBuilder<M, N>;
+    // TODO: do I care about buffer_protocol() here?
+    py::class_<BB>(m, pyclass_name.c_str(), py::buffer_protocol())
+        .def(py::init<Trie*>())
+        .def(
+            "BuildTree",
+            &BB::BuildTree,
+            py::return_value_policy::reference,
+            py::arg("arena"),
+            py::arg("dedupe")=false
+        )
+        .def("ParseBoard", &BB::ParseBoard)
+        .def("as_string",  &BB::as_string)
+        .def("Cell",    &BB::Cell)
+        .def("SetCell", &BB::SetCell)
+        .def("Details", &BB::Details)
+        .def("NumReps", &BB::NumReps)
+        .def("create_arena", &BB::CreateArena);
+}
+
+template<int M, int N>
+void declare_orderly_tree_builder(py::module &m, const string &pyclass_name) {
+    using BB = OrderlyTreeBuilder<M, N>;
     // TODO: do I care about buffer_protocol() here?
     py::class_<BB>(m, pyclass_name.c_str(), py::buffer_protocol())
         .def(py::init<Trie*>())
@@ -101,6 +124,11 @@ PYBIND11_MODULE(cpp_boggle, m)
     declare_tree_builder<3, 3>(m, "TreeBuilder33");
     declare_tree_builder<3, 4>(m, "TreeBuilder34");
     declare_tree_builder<4, 4>(m, "TreeBuilder44");
+
+    declare_orderly_tree_builder<2, 2>(m, "TreeBuilder22");
+    // declare_orderly_tree_builder<3, 3>(m, "TreeBuilder33");
+    // declare_orderly_tree_builder<3, 4>(m, "TreeBuilder34");
+    // declare_orderly_tree_builder<4, 4>(m, "TreeBuilder44");
 
     py::class_<ScoreDetails>(m, "ScoreDetails", py::buffer_protocol())
         .def_readwrite("max_nomark", &ScoreDetails::max_nomark)

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -118,6 +118,7 @@ PYBIND11_MODULE(cpp_boggle, m)
         .def("recompute_score", &EvalNode::RecomputeScore)
         .def("node_count", &EvalNode::NodeCount)
         .def("unique_node_count", &EvalNode::UniqueNodeCount)
+        .def("add_word", &EvalNode::AddWord)
         // TODO: remove this
         .def(
             "force_cell",
@@ -154,6 +155,7 @@ PYBIND11_MODULE(cpp_boggle, m)
         .def(py::init())
         .def("free_the_children", &EvalNodeArena::FreeTheChildren)
         .def("mark_and_sweep", &EvalNodeArena::MarkAndSweep)
+        .def("new_node", &EvalNodeArena::NewNode, py::return_value_policy::reference)
         .def("num_nodes", &EvalNodeArena::NumNodes);
 
     // TODO: remove this once it's not part of a public API.

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -65,15 +65,15 @@ void EvalNode::AddWord(vector<pair<int, int>> choices, int points, EvalNodeArena
   AddWordWork(choices.size(), choices.data(), points, arena);
 }
 
-void EvalNode::SetComputedFields(vector<string>& cells) {
+void EvalNode::SetComputedFields(vector<int>& num_letters) {
   for (auto c : children_) {
     if (c) {
-      ((EvalNode*)c)->SetComputedFields(cells);
+      ((EvalNode*)c)->SetComputedFields(num_letters);
     }
   }
 
   if (letter_ == CHOICE_NODE) {
-    choice_mask_ = cells[cell_].size() > 1 ? (1 << cell_) : 0;
+    choice_mask_ = num_letters[cell_] > 1 ? (1 << cell_) : 0;
     bound_ = 0;
     for (auto c : children_) {
       if (c) {

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -12,6 +12,59 @@ using namespace std;
 
 static const bool MERGE_TREES = true;
 
+inline int SortByLetter(const EvalNode* a, const EvalNode* b) {
+  return a->letter_ - b->letter_;
+}
+
+void EvalNode::AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena) {
+  if (!num_choices) {
+    points_ += points;
+    return;
+  }
+
+  auto cell = choices->first;
+  auto letter = choices->second;
+  choices++;
+  num_choices--;
+
+  // See Python for optimization TODOs
+  EvalNode* choice_child = NULL;
+  for (auto c : children_) {
+    if (c->cell_ == cell) {
+      choice_child = (EvalNode*)c;
+      break;
+    }
+  }
+  if (!choice_child) {
+    choice_child = new EvalNode;
+    choice_child->letter_ = CHOICE_NODE;
+    choice_child->cell_ = cell;
+    arena.AddNode(choice_child);
+    children_.push_back(choice_child);
+  }
+
+  EvalNode* letter_child = NULL;
+  for (auto c : choice_child->children_) {
+    if (c->letter_ == letter) {
+      letter_child = (EvalNode*)c;
+      break;
+    }
+  }
+  if (!letter_child) {
+    letter_child = new EvalNode;
+    letter_child->cell_ = cell;
+    letter_child->letter_ = letter;
+    arena.AddNode(letter_child);
+    choice_child->children_.push_back(letter_child);
+    sort(choice_child->children_.begin(), choice_child->children_.end(), SortByLetter);
+  }
+  letter_child->AddWordWork(num_choices, choices, points, arena);
+}
+
+void EvalNode::AddWord(vector<pair<int, int>> choices, int points, EvalNodeArena& arena) {
+  AddWordWork(choices.size(), choices.data(), points, arena);
+}
+
 const EvalNode* SqueezeChoiceChild(const EvalNode* child);
 bool SqueezeSumNodeInPlace(EvalNode* node, EvalNodeArena& arena, bool should_merge);
 
@@ -637,8 +690,7 @@ void EvalNode::ResetChoicePointMask() {
 
 template<typename T>
 int Arena<T>::MarkAndSweep(T* root, uint32_t mark) {
-  cerr << "MarkAndSweep not implemented" << endl;
-  exit(1);
+  throw new runtime_error("MarkAndSweep not implemented");
 }
 
 template <>
@@ -661,6 +713,18 @@ int Arena<EvalNode>::MarkAndSweep(EvalNode* root, uint32_t mark) {
 
   // cout << "Deleted " << num_deleted << " nodes, " << old_size << " -> " << owned_nodes_.size() << endl;
   return num_deleted;
+}
+
+template <typename T>
+T* Arena<T>::NewNode() {
+  throw new runtime_error("not implemented");
+}
+
+template <>
+EvalNode* Arena<EvalNode>::NewNode() {
+  EvalNode* n = new EvalNode;
+  AddNode(n);
+  return n;
 }
 
 const EvalNode* merge_trees(const EvalNode* a, const EvalNode* b, EvalNodeArena& arena);

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -70,7 +70,7 @@ class EvalNode {
   void AddWord(vector<pair<int, int>> choices, int points, EvalNodeArena& arena);
   void AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena);
 
-  void SetComputedFields(vector<string>& cells);
+  void SetComputedFields(vector<int>& num_letters);
 
   const EvalNode*
   LiftChoice(int cell, int num_lets, EvalNodeArena& arena, uint32_t mark, bool dedupe=false, bool compress=false) const;

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -44,6 +44,7 @@ class Arena {
     owned_nodes_.push_back(node);
   }
 
+  // For testing
   T* NewNode();
 
   // Returns the number of nodes deleted
@@ -68,6 +69,8 @@ class EvalNode {
 
   void AddWord(vector<pair<int, int>> choices, int points, EvalNodeArena& arena);
   void AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena);
+
+  void SetComputedFields(vector<string>& cells);
 
   const EvalNode*
   LiftChoice(int cell, int num_lets, EvalNodeArena& arena, uint32_t mark, bool dedupe=false, bool compress=false) const;

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -44,6 +44,8 @@ class Arena {
     owned_nodes_.push_back(node);
   }
 
+  T* NewNode();
+
   // Returns the number of nodes deleted
   int MarkAndSweep(T* root, uint32_t mark);
 
@@ -63,6 +65,9 @@ class EvalNode {
  public:
   EvalNode() : points_(0), choice_mask_(0), hash_(0) {}
   virtual ~EvalNode() {}
+
+  void AddWord(vector<pair<int, int>> choices, int points, EvalNodeArena& arena);
+  void AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena);
 
   const EvalNode*
   LiftChoice(int cell, int num_lets, EvalNodeArena& arena, uint32_t mark, bool dedupe=false, bool compress=false) const;
@@ -92,6 +97,7 @@ class EvalNode {
   static const int8_t CHOICE_NODE = -1;
 
   // These might be the various options on a cell or the various directions.
+  // TODO: the "const" here is increasingly a joke.
   vector<const EvalNode*> children_;
 
   // cached computation across all children

--- a/cpp/ibuckets.h
+++ b/cpp/ibuckets.h
@@ -74,6 +74,7 @@ class BucketBoggler {
   ScoreDetails details_;
 
   static const int NEIGHBORS[M*N][9];
+  static const int SPLIT_ORDER[M*N];
 
  private:
   unsigned int DoAllDescents(unsigned int idx, unsigned int len, Trie* t);
@@ -421,5 +422,18 @@ const int BucketBoggler<4, 4>::NEIGHBORS[4*4][9] = {
   {5, 9, 10, 11, 13, 15},
   {3, 10, 11, 14},
 };
+
+// poetry run python -m boggle.split_order
+template<>
+const int BucketBoggler<2, 2>::SPLIT_ORDER[2*2] = {0, 1, 2, 3};
+
+template<>
+const int BucketBoggler<3, 3>::SPLIT_ORDER[3*3] = {4, 5, 3, 1, 7, 0, 2, 6, 8};
+
+template<>
+const int BucketBoggler<3, 4>::SPLIT_ORDER[3*4] = {5, 6, 1, 9, 2, 10, 4, 7, 0, 8, 3, 11};
+
+template<>
+const int BucketBoggler<4, 4>::SPLIT_ORDER[4*4] = {5, 6, 9, 10, 1, 13, 2, 14, 4, 7, 8, 11, 0, 12, 3, 15};
 
 #endif  // BUCKET_H

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -13,6 +13,7 @@ class OrderlyTreeBuilder : public BucketBoggler<M, N> {
  public:
   OrderlyTreeBuilder(Trie* t) : BucketBoggler<M, N>(t) {
     for (int i = 0; i < M*N; i++) {
+      cout << i << endl;
       cell_to_order_[BucketBoggler<M, N>::SPLIT_ORDER[i]] = i;
     }
   }
@@ -54,11 +55,12 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
     DoAllDescents(cell, 0, 0, dict_, arena);
   }
 
-  vector<int> num_letters(0, M*N);
+  vector<int> num_letters(M*N, 0);
   for (int i = 0; i < M*N; i++) {
     num_letters[i] = strlen(bd_[i]);
+    cout << i << " " << num_letters[i] << endl;
   }
-  root_->SetComputedFields(num_letters);
+  // root_->SetComputedFields(num_letters);
   auto root = root_;
   root_ = NULL;
   arena.AddNode(root);
@@ -94,11 +96,19 @@ void OrderlyTreeBuilder<M, N>::DoDFS(int i, int n, int length, Trie* t, EvalNode
   if (t->IsWord()) {
     auto word_score = kWordScores[length];
 
-    vector<pair<int, int>> orderly_choices(choices_, choices_ + n);
+    vector<pair<int, int>> orderly_choices;
+    for (int j = 0; j < n; j++) {
+      orderly_choices.push_back(choices_[j]);
+    }
     // TODO: "this" capture could be avoided
     sort(orderly_choices.begin(), orderly_choices.end(), [this](const pair<int, int>& a, const pair<int, int>& b) {
       return cell_to_order_[a.first] < cell_to_order_[b.first];
     });
+    cout << "AddWord ";
+    for (auto c : orderly_choices) {
+      cout << "(" << c.first << ", " << c.second << ") ";
+    }
+    cout << word_score << " " << endl;
     root_->AddWord(orderly_choices, word_score, arena);
   }
 

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -1,0 +1,109 @@
+#ifndef ORDERLY_TREE_BUILDER_H
+#define ORDERLY_TREE_BUILDER_H
+
+#include "ibuckets.h"
+#include "eval_node.h"
+
+using namespace std;
+
+// TODO: inheritance isn't that helpful here.
+// TODO: templating on M, N probably isn't helpful, either.
+template <int M, int N>
+class OrderlyTreeBuilder : public BucketBoggler<M, N> {
+ public:
+  OrderlyTreeBuilder(Trie* t) : BucketBoggler<M, N>(t) {
+    for (int i = 0; i < M*N; i++) {
+      cell_to_order_[BucketBoggler<M, N>::SPLIT_ORDER[i]] = i;
+    }
+  }
+  virtual ~OrderlyTreeBuilder() {}
+
+  // These are "dependent names", see https://stackoverflow.com/a/1528010/388951.
+  using BucketBoggler<M, N>::dict_;
+  using BucketBoggler<M, N>::bd_;
+  using BucketBoggler<M, N>::used_;
+
+  /** Build an EvalTree for the current board. */
+  const EvalNode* BuildTree(EvalNodeArena& arena, bool dedupe=false);
+
+  unique_ptr<EvalNodeArena> CreateArena() {
+    return create_eval_node_arena();
+  }
+
+ private:
+  EvalNode* root_;
+  bool dedupe_;
+  int cell_to_order_[M*N];
+  pair<int, int> choices_[M*N];
+
+  // This one does not depend on M, N
+  void DoAllDescents(int cell, int n, int length, Trie* t, EvalNodeArena& arena);
+  void DoDFS(int cell, int n, int length, Trie* t, EvalNodeArena& arena);
+};
+
+template <int M, int N>
+const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool dedupe) {
+  // auto start = chrono::high_resolution_clock::now();
+  root_ = new EvalNode();
+  root_->letter_ = EvalNode::ROOT_NODE;
+  root_->cell_ = 0; // irrelevant
+  root_->points_ = 0;
+  used_ = 0;
+
+  for (int cell = 0; cell < M * N; cell++) {
+    DoAllDescents(cell, 0, 0, dict_, arena);
+  }
+
+  vector<int> num_letters(0, M*N);
+  for (int i = 0; i < M*N; i++) {
+    num_letters[i] = strlen(bd_[i]);
+  }
+  root_->SetComputedFields(num_letters);
+  auto root = root_;
+  root_ = NULL;
+  arena.AddNode(root);
+  return root;
+}
+
+template<int M, int N>
+void OrderlyTreeBuilder<M, N>::DoAllDescents(int cell, int n, int length, Trie* t, EvalNodeArena& arena) {
+  choices_[n] = {cell, 0};
+
+  for (int j = 0; j < n; j++) {
+    auto cc = bd_[cell][j] - 'a';
+    if (t->StartsWord(cc)) {
+      choices_[n].second = j;
+      DoDFS(cell, n + 1, length + (cc == kQ ? 2 : 1), t->Descend(cc), arena);
+    }
+  }
+}
+
+template<int M, int N>
+void OrderlyTreeBuilder<M, N>::DoDFS(int i, int n, int length, Trie* t, EvalNodeArena& arena) {
+  used_ ^= (1 << i);
+
+  auto& neighbors = BucketBoggler<M, N>::NEIGHBORS[i];
+  auto n_neighbors = neighbors[0];
+  for (int j = 1; j <= n_neighbors; j++) {
+    auto idx = neighbors[j];
+    if ((used_ & (1<<idx)) == 0) {
+      DoAllDescents(idx, n, length, t, arena);
+    }
+  }
+
+  if (t->IsWord()) {
+    auto word_score = kWordScores[length];
+
+    vector<pair<int, int>> orderly_choices(choices_, choices_ + n);
+    // TODO: "this" capture could be avoided
+    sort(orderly_choices.begin(), orderly_choices.end(), [this](const pair<int, int>& a, const pair<int, int>& b) {
+      return cell_to_order_[a.first] < cell_to_order_[b.first];
+    });
+    root_->AddWord(orderly_choices, word_score, arena);
+  }
+
+  used_ ^= (1 << i);
+}
+
+
+#endif // ORDERLY_TREE_BUILDER_H

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -13,7 +13,6 @@ class OrderlyTreeBuilder : public BucketBoggler<M, N> {
  public:
   OrderlyTreeBuilder(Trie* t) : BucketBoggler<M, N>(t) {
     for (int i = 0; i < M*N; i++) {
-      cout << i << endl;
       cell_to_order_[BucketBoggler<M, N>::SPLIT_ORDER[i]] = i;
     }
   }

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -71,7 +71,9 @@ template<int M, int N>
 void OrderlyTreeBuilder<M, N>::DoAllDescents(int cell, int n, int length, Trie* t, EvalNodeArena& arena) {
   choices_[n] = {cell, 0};
 
-  for (int j = 0; j < n; j++) {
+  // TODO: store num_letters array or iterate string
+  int n_chars = strlen(bd_[cell]);
+  for (int j = 0; j < n_chars; j++) {
     auto cc = bd_[cell][j] - 'a';
     if (t->StartsWord(cc)) {
       choices_[n].second = j;

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -58,9 +58,8 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
   vector<int> num_letters(M*N, 0);
   for (int i = 0; i < M*N; i++) {
     num_letters[i] = strlen(bd_[i]);
-    cout << i << " " << num_letters[i] << endl;
   }
-  // root_->SetComputedFields(num_letters);
+  root_->SetComputedFields(num_letters);
   auto root = root_;
   root_ = NULL;
   arena.AddNode(root);
@@ -106,11 +105,6 @@ void OrderlyTreeBuilder<M, N>::DoDFS(int i, int n, int length, Trie* t, EvalNode
     sort(orderly_choices.begin(), orderly_choices.end(), [this](const pair<int, int>& a, const pair<int, int>& b) {
       return cell_to_order_[a.first] < cell_to_order_[b.first];
     });
-    cout << "AddWord ";
-    for (auto c : orderly_choices) {
-      cout << "(" << c.first << ", " << c.second << ") ";
-    }
-    cout << word_score << " " << endl;
     root_->AddWord(orderly_choices, word_score, arena);
   }
 

--- a/testdata/add_word.txt
+++ b/testdata/add_word.txt
@@ -1,0 +1,24 @@
+ROOT (1) mask=7
+ CHOICE (0 <1) mask=7 points=0
+  b (0=0 0/1) mask=6
+   CHOICE (1 <1) mask=6 points=0
+    a (1=0 0/1) mask=4
+     CHOICE (2 <1) mask=4 points=0
+      n (2=0 1/1) mask=0
+      r (2=1 1/1) mask=0
+    e (1=1 0/1) mask=4
+     CHOICE (2 <1) mask=4 points=0
+      d (2=2 1/1) mask=0
+    i (1=2 0/1) mask=4
+     CHOICE (2 <1) mask=4 points=0
+      d (2=2 1/1) mask=0
+  c (0=1 0/1) mask=6
+   CHOICE (1 <1) mask=6 points=0
+    a (1=0 0/1) mask=4
+     CHOICE (2 <1) mask=4 points=0
+      n (2=0 1/1) mask=0
+  d (0=2 0/1) mask=6
+   CHOICE (1 <1) mask=6 points=0
+    i (1=2 0/1) mask=4
+     CHOICE (2 <1) mask=4 points=0
+      d (2=2 1/1) mask=0

--- a/testdata/orderly-3x3.txt
+++ b/testdata/orderly-3x3.txt
@@ -1,0 +1,199 @@
+ROOT (12) mask=208
+ CHOICE (4 <11) mask=208 points=0
+  l (4=0 0/11) mask=192
+   CHOICE (5 <7) mask=192 points=0
+    e (5=0 0/7) mask=192
+     CHOICE (7 <6) mask=192 points=0
+      a (7=0 2/3) mask=64
+       CHOICE (6 <1) mask=64 points=0
+        a (6=0 1/1) mask=0
+        i (6=2 1/1) mask=0
+        o (6=3 1/1) mask=0
+      e (7=1 4/6) mask=64
+       CHOICE (6 <2) mask=64 points=0
+        a (6=0 2/2) mask=0
+      i (7=2 2/2) mask=0
+      o (7=3 1/2) mask=64
+       CHOICE (6 <1) mask=64 points=0
+        a (6=0 1/1) mask=0
+        o (6=3 1/1) mask=0
+      u (7=4 1/1) mask=0
+     CHOICE (6 <1) mask=64 points=0
+      a (6=0 1/1) mask=0
+      o (6=3 1/1) mask=0
+   CHOICE (7 <4) mask=192 points=0
+    a (7=0 0/4) mask=64
+     CHOICE (6 <4) mask=64 points=0
+      a (6=0 4/4) mask=0
+      e (6=1 2/2) mask=0
+      i (6=2 1/1) mask=0
+    e (7=1 0/4) mask=64
+     CHOICE (6 <4) mask=64 points=0
+      a (6=0 2/2) mask=0
+      e (6=1 4/4) mask=0
+      i (6=2 2/2) mask=0
+      o (6=3 1/1) mask=0
+      u (6=4 1/1) mask=0
+    i (7=2 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 1/1) mask=0
+      e (6=1 2/2) mask=0
+      o (6=3 1/1) mask=0
+    o (7=3 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      e (6=1 1/1) mask=0
+      i (6=2 1/1) mask=0
+      o (6=3 2/2) mask=0
+    u (7=4 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      e (6=1 1/1) mask=0
+      u (6=4 2/2) mask=0
+  n (4=1 0/5) mask=192
+   CHOICE (5 <3) mask=192 points=0
+    e (5=0 0/3) mask=192
+     CHOICE (7 <2) mask=128 points=0
+      a (7=0 2/2) mask=0
+      e (7=1 2/2) mask=0
+      o (7=3 2/2) mask=0
+     CHOICE (6 <1) mask=64 points=0
+      a (6=0 1/1) mask=0
+      o (6=3 1/1) mask=0
+   CHOICE (7 <2) mask=192 points=0
+    a (7=0 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 2/2) mask=0
+      e (6=1 2/2) mask=0
+      i (6=2 2/2) mask=0
+    e (7=1 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 2/2) mask=0
+      e (6=1 2/2) mask=0
+      o (6=3 2/2) mask=0
+    i (7=2 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 2/2) mask=0
+      o (6=3 1/1) mask=0
+    o (7=3 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      e (6=1 2/2) mask=0
+      i (6=2 1/1) mask=0
+      o (6=3 2/2) mask=0
+  r (4=2 0/10) mask=192
+   CHOICE (5 <6) mask=192 points=0
+    e (5=0 0/6) mask=192
+     CHOICE (7 <4) mask=192 points=0
+      a (7=0 3/4) mask=64
+       CHOICE (6 <1) mask=64 points=0
+        a (6=0 1/1) mask=0
+        o (6=3 1/1) mask=0
+        u (6=4 1/1) mask=0
+      e (7=1 4/4) mask=0
+      i (7=2 2/2) mask=0
+      o (7=3 2/2) mask=0
+      u (7=4 1/3) mask=64
+       CHOICE (6 <2) mask=64 points=0
+        o (6=3 2/2) mask=0
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 2/2) mask=0
+      e (6=1 2/2) mask=0
+      i (6=2 1/1) mask=0
+      o (6=3 1/1) mask=0
+   CHOICE (7 <4) mask=192 points=0
+    a (7=0 0/3) mask=64
+     CHOICE (6 <3) mask=64 points=0
+      e (6=1 3/3) mask=0
+      i (6=2 2/2) mask=0
+      o (6=3 2/2) mask=0
+    e (7=1 0/4) mask=64
+     CHOICE (6 <4) mask=64 points=0
+      a (6=0 3/3) mask=0
+      e (6=1 4/4) mask=0
+      i (6=2 2/2) mask=0
+      o (6=3 2/2) mask=0
+      u (6=4 1/1) mask=0
+    i (7=2 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 2/2) mask=0
+      e (6=1 2/2) mask=0
+    o (7=3 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 2/2) mask=0
+      e (6=1 2/2) mask=0
+      u (6=4 1/1) mask=0
+    u (7=4 0/1) mask=64
+     CHOICE (6 <1) mask=64 points=0
+      e (6=1 1/1) mask=0
+      o (6=3 1/1) mask=0
+  s (4=3 0/7) mask=192
+   CHOICE (5 <5) mask=192 points=0
+    e (5=0 0/5) mask=192
+     CHOICE (7 <4) mask=192 points=0
+      a (7=0 2/4) mask=64
+       CHOICE (6 <2) mask=64 points=0
+        a (6=0 1/1) mask=0
+        e (6=1 2/2) mask=0
+      e (7=1 2/3) mask=64
+       CHOICE (6 <1) mask=64 points=0
+        a (6=0 1/1) mask=0
+      i (7=2 1/1) mask=0
+      o (7=3 2/2) mask=0
+      u (7=4 2/2) mask=0
+     CHOICE (6 <1) mask=64 points=0
+      o (6=3 1/1) mask=0
+      u (6=4 1/1) mask=0
+   CHOICE (7 <2) mask=192 points=0
+    a (7=0 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 2/2) mask=0
+      e (6=1 2/2) mask=0
+      i (6=2 1/1) mask=0
+      u (6=4 1/1) mask=0
+    e (7=1 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 2/2) mask=0
+      e (6=1 2/2) mask=0
+      i (6=2 1/1) mask=0
+      o (6=3 2/2) mask=0
+      u (6=4 2/2) mask=0
+    i (7=2 0/1) mask=64
+     CHOICE (6 <1) mask=64 points=0
+      a (6=0 1/1) mask=0
+      e (6=1 1/1) mask=0
+    o (7=3 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      e (6=1 2/2) mask=0
+      u (6=4 1/1) mask=0
+    u (7=4 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 1/1) mask=0
+      e (6=1 2/2) mask=0
+      o (6=3 1/1) mask=0
+  y (4=4 0/6) mask=192
+   CHOICE (5 <4) mask=192 points=0
+    e (5=0 0/4) mask=192
+     CHOICE (7 <2) mask=128 points=0
+      a (7=0 2/2) mask=0
+      e (7=1 2/2) mask=0
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 1/1) mask=0
+      e (6=1 2/2) mask=0
+   CHOICE (7 <2) mask=192 points=0
+    a (7=0 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      e (6=1 2/2) mask=0
+    e (7=1 0/2) mask=64
+     CHOICE (6 <2) mask=64 points=0
+      a (6=0 2/2) mask=0
+      e (6=1 2/2) mask=0
+    o (7=3 0/1) mask=64
+     CHOICE (6 <1) mask=64 points=0
+      u (6=4 1/1) mask=0
+    u (7=4 0/1) mask=64
+     CHOICE (6 <1) mask=64 points=0
+      o (6=3 1/1) mask=0
+ CHOICE (5 <1) mask=192 points=0
+  e (5=0 0/1) mask=192
+   CHOICE (7 <1) mask=192 points=0
+    a (7=0 0/1) mask=64
+     CHOICE (6 <1) mask=64 points=0
+      u (6=4 1/1) mask=0

--- a/testdata/sepeathtc-tree.txt
+++ b/testdata/sepeathtc-tree.txt
@@ -1,0 +1,19 @@
+ROOT (6) mask=0
+ CHOICE (4 <6) mask=0 points=0
+  a (4=0 0/6) mask=0
+   CHOICE (1 <2) mask=0 points=0
+    e (1=0 0/2) mask=0
+     CHOICE (7 <1) mask=0 points=0
+      t (7=0 0/1) mask=0
+       CHOICE (0 <1) mask=0 points=0
+        s (0=0 1/1) mask=0
+     CHOICE (0 <1) mask=0 points=0
+      s (0=0 1/1) mask=0
+   CHOICE (3 <4) mask=0 points=0
+    e (3=0 0/4) mask=0
+     CHOICE (7 <3) mask=0 points=0
+      t (7=0 1/3) mask=0
+       CHOICE (0 <2) mask=0 points=0
+        s (0=0 2/2) mask=0
+     CHOICE (0 <1) mask=0 points=0
+      s (0=0 1/1) mask=0


### PR DESCRIPTION
I wrote [last week][1] that "I don’t think there’s any tweaks to my current approach that will yield more than a 10x performance improvement." Then I had an insight! Inserting words into the EvalTree with the choices in board traversal order is a natural way to do it, but it is a choice. Rather than doing that, why not sort the choices to increase coherence?

This is a dramatic win. The initial bounds after building the tree drop by something like 5-20x. Lifting is less effective with these trees—the gap in bounds shrinks with every lift—but it never fully closes until the board is fully-lifted. This means that you can usually build the tree and go straight to `bound_remaining_boards` with no lifting, which saves a ton of memory. It's only for the very hardest boards where lifting is still helpful (and it is still extremely helpful).

- 50 board test set (3x4, 3 buckets): 333.2s → 40.1s, and only 700MB RAM peak.
- Board 234556: 275s → 319s (switchover 0), a loss! With switchover 4 it's only 24.4s, and switchover 5 is 17.5s.
- 20 board test set (4x4, 4 buckets): 1,014s → 236s (switchover=2) or 33s (mix).

Regardless, this is a huge win! And it should compound with letter grouping once #16 is fixed.

[1]: https://www.danvk.org/2025/02/13/boggle2025.html#:~:text=I%20don%E2%80%99t%20think%20there%E2%80%99s%20any%20tweaks%20to%20my%20current%20approach%20that%20will%20yield%20more%20than%20a%2010x%20performance%20improvement.