### PR TITLE
Add integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,17 @@ jobs:
 
     - name: Run tests
       run: poetry run pytest
+
+    - name: Integration test
+      run: |
+        /usr/bin/time -v poetry run python -m boggle.break_all \
+        'bdfgjvwxz aeiou lnrsy chkmpt' 1400 \
+        --size 34 \
+        --board_id 2520743 \
+        --switchover_level 0 \
+        --breaker=hybrid \
+        --log_per_board_stats \
+        --tree_builder orderly \
+        --omit_times \
+        > testdata/3x4-2520743-1400.txt && \
+        git diff --exit-code testdata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,4 @@ jobs:
 
     - name: Integration test
       run: |
-        /usr/bin/time -v poetry run python -m boggle.break_all \
-        'bdfgjvwxz aeiou lnrsy chkmpt' 1400 \
-        --size 34 \
-        --board_id 2520743 \
-        --switchover_level 0 \
-        --breaker=hybrid \
-        --log_per_board_stats \
-        --tree_builder orderly \
-        --omit_times \
-        > testdata/3x4-2520743-1400.txt && \
-        git diff --exit-code testdata
+        /usr/bin/time -v ./integration-test.sh

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -91,6 +91,10 @@ def break_worker(task: str | int):
     # all_details.append((task, details))
     with open(f"tasks-{me}.ndjson", "a") as out:
         summary = details.asdict()
+        if args.omit_times:
+            del summary["elapsed_s"]
+            del summary["free_time_s"]
+            del summary["secs_by_level"]
         summary["id"] = task
         out.write(json.dumps(summary))
         out.write("\n")
@@ -221,6 +225,11 @@ def main():
         action="store_true",
         help="Log progress and stats during breaking, which may slow it down.",
     )
+    parser.add_argument(
+        "--omit_times",
+        action="store_true",
+        help="Omit times from logging, to get deterministic output.",
+    )
     args = parser.parse_args()
     if args.random_seed >= 0:
         random.seed(args.random_seed)
@@ -307,7 +316,8 @@ def main():
 
     end_s = time.time()
 
-    print(f"Broke {len(indices)} classes in {end_s-start_s:.02f}s.")
+    if not args.omit_times:
+        print(f"Broke {len(indices)} classes in {end_s-start_s:.02f}s.")
     print(f"Found {len(good_boards)} breaking failure(s):")
     print("\n".join(good_boards))
 

--- a/boggle/exhaustive_search.py
+++ b/boggle/exhaustive_search.py
@@ -1,76 +1,51 @@
 #!/usr/bin/env python
 """Find the highest-scoring board via exhaustive search.
 
-This is only really feasible for very small (2x2) boards.
-For 2x2, the best board is:
+Exhaustive search over all boards is only really feasible for very
+small (2x2) boards. For 2x2, the best board is:
 
   A S
   E T
 
 with 18 points on it.
+
+For larger boards, it's possible to search within a board class.
 """
 
-import heapq
+import argparse
 import itertools
 import math
-import sys
 
-from cpp_boggle import Boggler34, Trie
 from tqdm import tqdm
 
-from boggle.boggler import PyBoggler
-from boggle.trie import make_py_trie
+from boggle.args import add_standard_args, get_trie_and_boggler_from_args
 
 
 def main_class():
-    t = Trie.CreateFromFile("wordlists/enable2k.txt")
-    (board,) = sys.argv[1:]
-    cells = board.split(" ")
-    assert len(cells) == 3 * 4
-    b = Boggler34(t)
+    parser = argparse.ArgumentParser(
+        prog="Exhaustive search within a board class",
+        description="Find all the boggle boards above a certain score within a class.",
+    )
+    add_standard_args(parser, python=True)
 
-    best_score = 0
+    parser.add_argument("cutoff", type=int, help="Minimum score to keep.")
+    parser.add_argument("board", type=str, help="Board class to exhaustively search.")
+    args = parser.parse_args()
+
+    cutoff = args.cutoff
+    board = args.board
+    cells = board.split(" ")
     total = math.prod(len(c) for c in cells)
-    top100 = []
-    threshold = 0
+
+    _t, boggler = get_trie_and_boggler_from_args(args)
 
     for letters in tqdm(itertools.product(*cells), total=total):
         board = "".join(letters)
-        score = b.score(board)
-        if score < threshold:
+        score = boggler.score(board)
+        if score < cutoff:
             continue
-
-        if len(top100) < 100:
-            heapq.heappush(top100, (score, board))
-        else:
-            worst_score, _ = heapq.heappushpop(top100, (score, board))
-            threshold = worst_score
-        if score > best_score:
-            best_score = score
-            print(f"New best board: {board} {best_score}")
-
-    for i, (score, bd) in enumerate(sorted(top100, reverse=True)):
-        print(f"{i:3d} {score}: {bd}")
-
-
-def main22():
-    t = make_py_trie("wordlists/enable2k.txt")
-    boggler = PyBoggler(t, (2, 2))
-
-    atoz = "".join(chr(x) for x in range(ord("a"), ord("z") + 1))
-    boards = itertools.product(atoz, repeat=4)
-
-    best_score = 0
-    # best_board = None
-    for board in tqdm(boards, total=26**4):
-        boggler.set_board("".join(board))
-        score = boggler.score()
-        if score > best_score:
-            print(score, board)
-            best_score = score
-            # best_board = board
+        print(f"{score}\t{board}")
 
 
 if __name__ == "__main__":
-    # main22()
     main_class()

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -15,13 +15,11 @@ import argparse
 import random
 from collections import Counter
 
-from cpp_boggle import Trie
 
 from boggle.anneal import initial_board
 from boggle.args import add_standard_args, get_trie_and_boggler_from_args
 from boggle.boggler import PyBoggler
-from boggle.dimensional_bogglers import Bogglers
-from boggle.trie import LETTER_A, make_py_trie
+from boggle.trie import LETTER_A
 
 
 def neighbors(board: str):

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -18,7 +18,7 @@ from collections import Counter
 from cpp_boggle import Trie
 
 from boggle.anneal import initial_board
-from boggle.args import add_standard_args
+from boggle.args import add_standard_args, get_trie_and_boggler_from_args
 from boggle.boggler import PyBoggler
 from boggle.dimensional_bogglers import Bogglers
 from boggle.trie import LETTER_A, make_py_trie
@@ -119,16 +119,9 @@ def main():
     if args.random_seed >= 0:
         random.seed(args.random_seed)
 
-    w, h = dims = args.size // 10, args.size % 10
+    w, h = args.size // 10, args.size % 10
 
-    if args.python:
-        t = make_py_trie(args.dictionary)
-        assert t
-        boggler = PyBoggler(t, dims)
-    else:
-        t = Trie.CreateFromFile(args.dictionary)
-        assert t
-        boggler = Bogglers[dims](t)
+    _t, boggler = get_trie_and_boggler_from_args(args)
 
     best = Counter[str]()
     for run in range(args.num_boards):

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -8,7 +8,7 @@ from boggle.eval_tree import (
     EvalNode,
     create_eval_node_arena_py,
 )
-from boggle.ibuckets import PyBucketBoggler
+from boggle.ibuckets import PyBucketBoggler, ScoreDetails
 from boggle.split_order import SPLIT_ORDER
 from boggle.trie import PyTrie
 
@@ -30,6 +30,7 @@ class OrderlyTreeBuilder(PyBucketBoggler):
         root.letter = ROOT_NODE
         root.cell = 0  # irrelevant
         root.points = 0
+        self.details_ = ScoreDetails(0, 0, -1)
         self.root = root
         self.used_ = 0
 
@@ -38,6 +39,7 @@ class OrderlyTreeBuilder(PyBucketBoggler):
         num_letters = [len(cell) for cell in self.bd_]
         root.set_computed_fields(num_letters)
         self.root = None
+        self.details_.max_nomark = self.root.bound
         return root
 
     # TODO: rename these methods

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -39,7 +39,7 @@ class OrderlyTreeBuilder(PyBucketBoggler):
         num_letters = [len(cell) for cell in self.bd_]
         root.set_computed_fields(num_letters)
         self.root = None
-        self.details_.max_nomark = self.root.bound
+        self.details_.max_nomark = root.bound
         return root
 
     # TODO: rename these methods

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -22,6 +22,7 @@ class OrderlyTreeBuilder : public BucketBoggler<M, N> {
   using BucketBoggler<M, N>::dict_;
   using BucketBoggler<M, N>::bd_;
   using BucketBoggler<M, N>::used_;
+  using BucketBoggler<M, N>::details_;
 
   /** Build an EvalTree for the current board. */
   const EvalNode* BuildTree(EvalNodeArena& arena, bool dedupe=false);

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -50,6 +50,11 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
   root_->points_ = 0;
   used_ = 0;
 
+  // TODO: remove this if I disentangle OrderlyTreeBuilder and BucketBoggler.
+  details_.max_nomark = 0;
+  details_.sum_union = 0;
+  details_.bailout_cell = -1;
+
   for (int cell = 0; cell < M * N; cell++) {
     DoAllDescents(cell, 0, 0, dict_, arena);
   }
@@ -62,6 +67,7 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
   auto root = root_;
   root_ = NULL;
   arena.AddNode(root);
+  details_.max_nomark = root->bound_;
   return root;
 }
 

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -o errexit
+
+poetry run python -m boggle.break_all \
+    'bdfgjvwxz aeiou lnrsy chkmpt' 1400 \
+    --size 34 \
+    --board_id 2520743 \
+    --switchover_level 0 \
+    --breaker=hybrid \
+    --log_per_board_stats \
+    --tree_builder orderly \
+    --omit_times \
+    > testdata/3x4-2520743-1400.txt
+
+git diff --exit-code testdata

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -1,0 +1,66 @@
+Unable to break board: cerslatesind 1406
+Unable to break board: merslatesind 1440
+Unable to break board: perslatesind 1651
+Unable to break board: perslatesing 1528
+Unable to break board: perssatelind 1487
+Unable to break board: terssatelind 1432
+Unable to break board: pinslateserd 1460
+Unable to break board: marslitesand 1432
+Unable to break board: parslitesand 1507
+Unable to break board: parslitesang 1406
+Unable to break board: pansliteserd 1448
+Unable to break board: perslitesand 1417
+Found unbreakable board for 2520743: cerslatesind
+Found unbreakable board for 2520743: merslatesind
+Found unbreakable board for 2520743: perslatesind
+Found unbreakable board for 2520743: perslatesing
+Found unbreakable board for 2520743: perssatelind
+Found unbreakable board for 2520743: terssatelind
+Found unbreakable board for 2520743: pinslateserd
+Found unbreakable board for 2520743: marslitesand
+Found unbreakable board for 2520743: parslitesand
+Found unbreakable board for 2520743: parslitesang
+Found unbreakable board for 2520743: pansliteserd
+Found unbreakable board for 2520743: perslitesand
+2520743: chkmpt aeiou lnrsy lnrsy lnrsy aeiou chkmpt aeiou lnrsy aeiou lnrsy bdfgjvwxz
+{
+  "num_reps": 632812500,
+  "failures": [
+    "cerslatesind",
+    "merslatesind",
+    "perslatesind",
+    "perslatesing",
+    "perssatelind",
+    "terssatelind",
+    "pinslateserd",
+    "marslitesand",
+    "parslitesand",
+    "parslitesang",
+    "pansliteserd",
+    "perslitesand"
+  ],
+  "elim_level": {},
+  "sum_union": 0,
+  "bounds": {
+    "0": 6652
+  },
+  "boards_to_test": 8078,
+  "init_nodes": 1960065,
+  "total_nodes": 1960065,
+  "freed_nodes": 0,
+  "num_filtered": {},
+  "id": 2520743
+}
+Found 12 breaking failure(s):
+cerslatesind
+merslatesind
+perslatesind
+perslatesing
+perssatelind
+terssatelind
+pinslateserd
+marslitesand
+parslitesand
+parslitesang
+pansliteserd
+perslitesand


### PR DESCRIPTION
Fixes #26 
Fixes #27 

This finds all the boards with more than 1400 points in a specific class. These have been verified via exhaustive search, which took ~38 minutes vs ~6 seconds for `break_all.py`. Behold, the power of algorithms! ⚡️

```
$ poetry run python -m boggle.exhaustive_search --size 34 1400 'chkmpt aeiou lnrsy lnrsy lnrsy aeiou chkmpt aeiou lnrsy aeiou lnrsy bdfgjvwxz'
1406	cerslatesind
1432	marslitesand
1440	merslatesind
1448	pansliteserd
1507	parslitesand
1406	parslitesang
1651	perslatesind
1528	perslatesing
1417	perslitesand
1487	perssatelind
1460	pinslateserd
1432	terssatelind

poetry run python -m boggle.exhaustive_search --size 34 1400   2285.24s user 6.76s system 99% cpu 38:26.01 total

```