### PR TITLE
Make `--letter_grouping` easier to use

### DIFF
--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -29,6 +29,7 @@ from boggle.dimensional_bogglers import (
 )
 from boggle.eval_tree import EvalTreeBoggler
 from boggle.ibuckets import PyBucketBoggler
+from boggle.letter_grouping import filter_to_canonical
 from boggle.orderly_tree_builder import OrderlyTreeBuilder
 from boggle.trie import PyTrie, get_letter_map
 
@@ -74,6 +75,10 @@ def break_worker(task: str | int):
     assert best_score > 0
     classes = args.classes.split(" ")
     dims = args.size // 10, args.size % 10
+    if args.letter_grouping:
+        letter_map = get_letter_map(args.letter_grouping)
+        classes = [filter_to_canonical(cls, letter_map) for cls in classes]
+        # print(f'Filtered {args.classes} -> {" ".join(classes)}')
 
     if isinstance(task, int):
         if needs_canonical_filter and not is_canonical_board_id(
@@ -255,12 +260,6 @@ def main():
     assert 3 <= w <= 4
     assert 3 <= h <= 4
     max_index = num_classes ** (w * h)
-
-    if args.letter_grouping:
-        letter_map = get_letter_map(args.letter_grouping)
-        for lets in classes:
-            for c in lets:
-                assert letter_map[c] == c, f"Letter classes must be canonical ({c})"
 
     completed_ids = set()
     if args.resume_from:

--- a/boggle/letter_grouping.py
+++ b/boggle/letter_grouping.py
@@ -33,3 +33,7 @@ def reverse_letter_map(letter_map: dict[str, str]):
     for k in out:
         out[k] = "".join(sorted(out[k]))
     return out
+
+
+def filter_to_canonical(word: str, letter_map: dict[str, str]):
+    return "".join(letter for letter in word if letter_map[letter] == letter)


### PR DESCRIPTION
Now it will filter the letter buckets for you. This seems more useful when you do a lot of lifting. For example:

- 234556 with switchover=4: 23.32→20.12s (14% win), 2.74→2.35GB RAM (13% win)
- 50 board test set with switchover=2: 33→38s (15% loss), ~3% RAM savings.