### PR TITLE
Add --switchover_sizes CLI flag

### DIFF
--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -136,7 +136,7 @@ def get_breaker(args) -> BreakingBundle:
 
     if args.breaker == "hybrid":
         switchover_level = 2
-        if args.switchover_level:
+        if args.switchover_level is not None:
             switchover_level = args.switchover_level
         elif args.switchover_sizes:
             switchover_level = [

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -135,7 +135,7 @@ def get_breaker(args) -> BreakingBundle:
     etb = builder[(args.python, args.tree_builder)](t, dims)
 
     if args.breaker == "hybrid":
-        switchover_level = 4
+        switchover_level = 2
         if args.switchover_level:
             switchover_level = args.switchover_level
         elif args.switchover_sizes:
@@ -203,7 +203,7 @@ def main():
         type=int,
         default=None,
         help="Depth at which to switch from lifting choices to exhaustively trying them. "
-        "Default is 4, unless you set --switchover_sizes. Only relevant with --breaker=hybrid.",
+        "Default is 2, unless you set --switchover_sizes. Only relevant with --breaker=hybrid.",
     )
     switchovers.add_argument(
         "--switchover_sizes",

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -135,12 +135,20 @@ def get_breaker(args) -> BreakingBundle:
     etb = builder[(args.python, args.tree_builder)](t, dims)
 
     if args.breaker == "hybrid":
+        switchover_level = 4
+        if args.switchover_level:
+            switchover_level = args.switchover_level
+        elif args.switchover_sizes:
+            switchover_level = [
+                tuple(int(x) for x in pair.split(":"))
+                for pair in args.switchover_sizes.split(",")
+            ]
         breaker = HybridTreeBreaker(
             etb,
             boggler,
             dims,
             best_score,
-            switchover_level=args.switchover_level,
+            switchover_level=switchover_level,
             free_after_lift=args.free_after_lift,
             log_breaker_progress=args.log_breaker_progress,
             letter_grouping=args.letter_grouping,
@@ -189,12 +197,20 @@ def main():
         default=4,
         help="Number of partitions to use when breaking a bucket. Only relevant with --breaker=ibuckets.",
     )
-    parser.add_argument(
-        # TODO: figure out how to set this based on tree size
+    switchovers = parser.add_mutually_exclusive_group()
+    switchovers.add_argument(
         "--switchover_level",
         type=int,
-        default=4,
-        help="Depth at which to switch from lifting choices to exhaustively trying them. Only relevant with --breaker=hybrid.",
+        default=None,
+        help="Depth at which to switch from lifting choices to exhaustively trying them. "
+        "Default is 4, unless you set --switchover_sizes. Only relevant with --breaker=hybrid.",
+    )
+    switchovers.add_argument(
+        "--switchover_sizes",
+        type=str,
+        default=None,
+        help='Initial size -> switchover map. Format is "switch:size,switch:size". For example, '
+        '"2:100,4:1000" would use switchover=0 for 0-99, 2 for 100-999, and 4 for 1000+.',
     )
     parser.add_argument(
         "--breaker",

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -132,7 +132,7 @@ class HybridTreeBreaker:
             )
 
         if isinstance(self.switchover_level_input, int):
-            self.switchover_level = self.switchover_level
+            self.switchover_level = self.switchover_level_input
         else:
             self.switchover_level = 0
             for level, size in self.switchover_level_input:

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -5,7 +5,6 @@ poetry run python -m boggle.break_all \
     'bdfgjvwxz aeiou lnrsy chkmpt' 1400 \
     --size 34 \
     --board_id 2520743 \
-    --switchover_level 0 \
     --log_per_board_stats \
     --omit_times \
     > testdata/3x4-2520743-1400.txt

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -42,7 +42,8 @@ Found unbreakable board for 2520743: perslitesand
   "elim_level": {},
   "sum_union": 0,
   "bounds": {
-    "0": 6652
+    "0": 6652,
+    "1": 5691
   },
   "nodes": {
     "0": 1960065
@@ -50,7 +51,7 @@ Found unbreakable board for 2520743: perslitesand
   "boards_to_test": 8078,
   "expanded_to_test": 8078,
   "init_nodes": 1960065,
-  "total_nodes": 1960065,
+  "total_nodes": 2362581,
   "freed_nodes": 0,
   "num_filtered": {},
   "id": 2520743

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -42,8 +42,7 @@ Found unbreakable board for 2520743: perslitesand
   "elim_level": {},
   "sum_union": 0,
   "bounds": {
-    "0": 6652,
-    "1": 5691
+    "0": 6652
   },
   "nodes": {
     "0": 1960065
@@ -51,7 +50,7 @@ Found unbreakable board for 2520743: perslitesand
   "boards_to_test": 8078,
   "expanded_to_test": 8078,
   "init_nodes": 1960065,
-  "total_nodes": 2362581,
+  "total_nodes": 1960065,
   "freed_nodes": 0,
   "num_filtered": {},
   "id": 2520743


### PR DESCRIPTION
`--switchover_sizes 2:2000000,4:5400000` seems to [work well][1] for 3x4 Boggle. This definitely doesn't always choose the best switchover level, but it does avoid forcing you into a one-size-fits-all choice.

I think picking the optimal time to switch would involve knowing the future. If you lift and blow up too much without filtering anything, then lifting wasn't a good idea.

It's also curious that switchover=1 and 3 were never the optimal choice on the boards I tested.

[1]: https://docs.google.com/spreadsheets/d/1uG-KFJFdOS7MQcibcdloTtQEQAdwror6VA0BO0AhkYQ/edit?gid=1912652207#gid=1912652207