### PR TITLE
Per cell buckets

### DIFF
--- a/boggle/board_id.py
+++ b/boggle/board_id.py
@@ -141,6 +141,37 @@ def is_canonical_board_id(num_classes: int, dims: tuple[int, int], idx: int):
     return r == idx
 
 
+CELL_TYPES = {"center", "edge", "corner"}
+
+
+def cell_type_for_index(idx: int, dims: tuple[int, int]):
+    w, h = dims
+    y = idx % h
+    x = idx // h
+    ex = x == 0 or x == w - 1
+    ey = y == 0 or y == h - 1
+    if ex and ey:
+        return "corner"
+    elif ex or ey:
+        return "edge"
+    return "center"
+
+
+def parse_classes(classes: str, dims: tuple[int, int]):
+    w, h = dims
+    clauses = [clause.strip() for clause in classes.split(",")]
+    cell_types = {}
+    for clause in clauses:
+        if ":" in clause:
+            where, what = (c.trim() for c in clause.split(":"))
+            assert where in CELL_TYPES
+            cell_types[where] = what.split(" ")
+        else:
+            for type in CELL_TYPES:
+                cell_types[type] = clause.split(" ")
+    print(cell_types)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Go between board IDs and board classes",

--- a/boggle/board_id.py
+++ b/boggle/board_id.py
@@ -2,27 +2,25 @@ import argparse
 from typing import Sequence
 
 
-# TODO: classes: list[str] -> list[list[str]]
-def from_board_id(classes: list[str], dims: tuple[int, int], idx: int) -> str:
-    w, h = dims
-    num_classes = len(classes)
+def from_board_id(cell_classes: list[list[str]], idx: int) -> str:
     board: list[str] = []
     left = idx
     # print("from_board_id")
-    for i in range(0, w * h):
+    for classes in cell_classes:
         # print(left % num_classes)
-        board.append(classes[left % num_classes])
-        left //= num_classes
+        board.append(classes[left % len(classes)])
+        left //= len(classes)
     assert left == 0
     return " ".join(board)
 
 
 # TODO: num_classes: int -> list[int]
-def board_id(bd: list[list[int]], dims: tuple[int, int], num_classes: int) -> int:
-    w, h = dims
+def board_id(bd: list[list[int]], num_classes: list[int]) -> int:
+    h = len(bd)
+    w = len(bd[0])
     id = 0
     for i in range(w * h - 1, -1, -1):
-        id *= num_classes
+        id *= num_classes[i]
         id += bd[i % h][i // h]
     return id
 
@@ -53,7 +51,7 @@ def swap(ary, a, b):
 
 # TODO: num_classes: int -> list[int]
 # TODO: can probably express this all more concisely in Python
-def canonicalize_id(num_classes: int, dims: tuple[int, int], idx: int):
+def canonicalize_id(num_classes: list[int], dims: tuple[int, int], idx: int):
     """Return an index for a more canonical version of this board.
 
     Returns the original board ID if there is no such index.
@@ -64,10 +62,11 @@ def canonicalize_id(num_classes: int, dims: tuple[int, int], idx: int):
     bd = [[0 for _x in range(0, w)] for _y in range(0, h)]
     left = idx
 
+    # TODO: call to_2d
     # dims=(3, 4): bd is 4x3; len(bd) == 4, len(bd[0]) == 3
     for i in range(0, w * h):
-        bd[i % h][i // h] = left % num_classes
-        left //= num_classes
+        bd[i % h][i // h] = left % num_classes[i]
+        left //= num_classes[i]
     assert left == 0
 
     # if dims == (3, 4):
@@ -83,7 +82,7 @@ def canonicalize_id(num_classes: int, dims: tuple[int, int], idx: int):
         for j in range(0, w // 2):
             for i in range(0, h):
                 swap(bd, (j, i), (w - 1 - j, i))
-        other = board_id(bd, dims, num_classes)
+        other = board_id(bd, num_classes)
         if other < idx:
             return other
 
@@ -93,7 +92,7 @@ def canonicalize_id(num_classes: int, dims: tuple[int, int], idx: int):
         for j in range(0, h // 2):
             for i in range(0, w):
                 swap(bd, (i, j), (i, h - 1 - j))
-        other = board_id(bd, dims, num_classes)
+        other = board_id(bd, num_classes)
         if other < idx:
             return other
 
@@ -103,7 +102,7 @@ def canonicalize_id(num_classes: int, dims: tuple[int, int], idx: int):
         for j in range(0, w // 2):
             for i in range(0, h):
                 swap(bd, (j, i), (w - 1 - j, i))
-        other = board_id(bd, dims, num_classes)
+        other = board_id(bd, num_classes)
         if other < idx:
             return other
 
@@ -120,7 +119,7 @@ def canonicalize_id(num_classes: int, dims: tuple[int, int], idx: int):
             for j in range(0, i):
                 swap(bd, (i, j), (j, i))
 
-        other = board_id(bd, dims, num_classes)
+        other = board_id(bd, num_classes)
         if other < idx:
             return other
 
@@ -128,7 +127,7 @@ def canonicalize_id(num_classes: int, dims: tuple[int, int], idx: int):
 
 
 # TODO: num_classes: int -> list[int]
-def get_canonical_board_id(num_classes: int, dims: tuple[int, int], idx: int):
+def get_canonical_board_id(num_classes: list[int], dims: tuple[int, int], idx: int):
     other = canonicalize_id(num_classes, dims, idx)
     if other == idx:
         return idx
@@ -136,7 +135,7 @@ def get_canonical_board_id(num_classes: int, dims: tuple[int, int], idx: int):
 
 
 # TODO: num_classes: int -> list[int]
-def is_canonical_board_id(num_classes: int, dims: tuple[int, int], idx: int):
+def is_canonical_board_id(num_classes: list[int], dims: tuple[int, int], idx: int):
     r = canonicalize_id(num_classes, dims, idx)
     return r == idx
 

--- a/boggle/board_id.py
+++ b/boggle/board_id.py
@@ -2,6 +2,7 @@ import argparse
 from typing import Sequence
 
 
+# TODO: classes: list[str] -> list[list[str]]
 def from_board_id(classes: list[str], dims: tuple[int, int], idx: int) -> str:
     w, h = dims
     num_classes = len(classes)
@@ -16,6 +17,7 @@ def from_board_id(classes: list[str], dims: tuple[int, int], idx: int) -> str:
     return " ".join(board)
 
 
+# TODO: num_classes: int -> list[int]
 def board_id(bd: list[list[int]], dims: tuple[int, int], num_classes: int) -> int:
     w, h = dims
     id = 0
@@ -49,6 +51,7 @@ def swap(ary, a, b):
     ary[ay][ax], ary[by][bx] = ary[by][bx], ary[ay][ax]
 
 
+# TODO: num_classes: int -> list[int]
 # TODO: can probably express this all more concisely in Python
 def canonicalize_id(num_classes: int, dims: tuple[int, int], idx: int):
     """Return an index for a more canonical version of this board.
@@ -124,6 +127,7 @@ def canonicalize_id(num_classes: int, dims: tuple[int, int], idx: int):
     return idx
 
 
+# TODO: num_classes: int -> list[int]
 def get_canonical_board_id(num_classes: int, dims: tuple[int, int], idx: int):
     other = canonicalize_id(num_classes, dims, idx)
     if other == idx:
@@ -131,6 +135,7 @@ def get_canonical_board_id(num_classes: int, dims: tuple[int, int], idx: int):
     return get_canonical_board_id(num_classes, dims, other)
 
 
+# TODO: num_classes: int -> list[int]
 def is_canonical_board_id(num_classes: int, dims: tuple[int, int], idx: int):
     r = canonicalize_id(num_classes, dims, idx)
     return r == idx
@@ -153,6 +158,8 @@ def main():
     parser.add_argument("boards", nargs="+", help="Board classes (space-delimited)")
 
     args = parser.parse_args()
+    # TODO: implement parse_classes(args.classes, dims)
+    # --classes="center:aeiou blah, edge:aeiou blah, corner:aeiou blah"
     classes = args.classes.split(" ")
     n_classes = len(classes)
     w, h = dims = args.size // 10, args.size % 10

--- a/boggle/board_id.py
+++ b/boggle/board_id.py
@@ -163,13 +163,14 @@ def parse_classes(classes: str, dims: tuple[int, int]):
     cell_types = {}
     for clause in clauses:
         if ":" in clause:
-            where, what = (c.trim() for c in clause.split(":"))
+            where, what = (c.strip() for c in clause.split(":"))
             assert where in CELL_TYPES
             cell_types[where] = what.split(" ")
         else:
             for type in CELL_TYPES:
                 cell_types[type] = clause.split(" ")
-    print(cell_types)
+
+    return [cell_types[cell_type_for_index(i, dims)] for i in range(w * h)]
 
 
 def main():

--- a/boggle/board_id_test.py
+++ b/boggle/board_id_test.py
@@ -6,6 +6,7 @@ from boggle.board_id import (
     from_board_id,
     get_canonical_board_id,
     is_canonical_board_id,
+    parse_classes,
     to_1d,
     to_2d,
 )
@@ -129,3 +130,18 @@ def test_cell_type_for_index():
     )
     for i in range(16):
         assert cell_type_for_index(i, (4, 4)) == four[i]
+
+
+def test_parse_classes():
+    assert parse_classes("c v", (3, 3)) == [["c", "v"] for _ in range(9)]
+    assert parse_classes("center:a b c d, edge:x y z, corner:c v", (3, 3)) == [
+        ["c", "v"],
+        ["x", "y", "z"],
+        ["c", "v"],
+        ["x", "y", "z"],
+        ["a", "b", "c", "d"],
+        ["x", "y", "z"],
+        ["c", "v"],
+        ["x", "y", "z"],
+        ["c", "v"],
+    ]

--- a/boggle/board_id_test.py
+++ b/boggle/board_id_test.py
@@ -67,6 +67,38 @@ def test_best_34():
     ]
 
 
+def test_best_34_per_cell():
+    classes = parse_classes(
+        "center:aeiou bfgpst xyz djlmnrvw chkq, edge:aeijou bcdfgmpqvwxz hklnrsty, corner:aeiou bcdfghjklmnpqrstvwxyz",
+        (3, 4),
+    )
+    assert len(classes) == 12
+    num_classes = [len(cls) for cls in classes]
+
+    best = "s i n d l a t e p e r s".split(" ")
+    best_classes = " ".join(
+        [next(c for c in classes[i] if x in c) for i, x in enumerate(best)]
+    )
+    best_idxs = [
+        next(i for i, c in enumerate(classes[j]) if x in c) for j, x in enumerate(best)
+    ]
+    assert best_idxs == snapshot([1, 0, 2, 1, 2, 0, 1, 0, 1, 0, 2, 1])
+    best_idxs2d = to_2d(best_idxs, (3, 4))
+    assert board_id(best_idxs2d, num_classes) == 251743
+    assert from_board_id(classes, 251743) == best_classes
+    assert get_canonical_board_id(num_classes, (3, 4), 251743) == 191831
+    canonical_best_class = from_board_id(classes, 191831)
+    best_2d = to_2d(canonical_best_class.split(" "), (3, 4))
+    assert best_2d == snapshot(
+        [
+            ["bcdfghjklmnpqrstvwxyz", "aeijou", "bcdfghjklmnpqrstvwxyz"],  # S E D
+            ["hklnrsty", "bfgpst", "hklnrsty"],  # R T N
+            ["aeijou", "aeiou", "aeijou"],  # E A I
+            ["bcdfghjklmnpqrstvwxyz", "hklnrsty", "bcdfghjklmnpqrstvwxyz"],  # P L S
+        ]
+    )
+
+
 def test_2d_1d_round_trip():
     board = "sindlatepers"
     bd2d = to_2d(board, (3, 4))

--- a/boggle/board_id_test.py
+++ b/boggle/board_id_test.py
@@ -1,5 +1,8 @@
+from inline_snapshot import snapshot
+
 from boggle.board_id import (
     board_id,
+    cell_type_for_index,
     from_board_id,
     get_canonical_board_id,
     is_canonical_board_id,
@@ -79,3 +82,50 @@ def test_2d_1d_round_trip():
         ["n", "t", "r", "c"],
         ["d", "e", "s", "d"],
     ]
+
+
+def test_cell_type_for_index():
+    assert cell_type_for_index(0, (3, 3)) == "corner"
+    assert cell_type_for_index(1, (3, 3)) == "edge"
+    assert cell_type_for_index(2, (3, 3)) == "corner"
+    assert cell_type_for_index(4, (3, 3)) == "center"
+
+    assert {i: cell_type_for_index(i, (3, 4)) for i in range(12)} == snapshot(
+        {
+            0: "corner",
+            1: "edge",
+            2: "edge",
+            3: "corner",
+            4: "edge",
+            5: "center",
+            6: "center",
+            7: "edge",
+            8: "corner",
+            9: "edge",
+            10: "edge",
+            11: "corner",
+        }
+    )
+
+    four = snapshot(
+        {
+            0: "corner",
+            1: "edge",
+            2: "edge",
+            3: "corner",
+            4: "edge",
+            5: "center",
+            6: "center",
+            7: "edge",
+            8: "edge",
+            9: "center",
+            10: "center",
+            11: "edge",
+            12: "corner",
+            13: "edge",
+            14: "edge",
+            15: "corner",
+        }
+    )
+    for i in range(16):
+        assert cell_type_for_index(i, (4, 4)) == four[i]

--- a/boggle/board_id_test.py
+++ b/boggle/board_id_test.py
@@ -13,35 +13,38 @@ from boggle.board_id import (
 
 
 def test_board_id_round_trip33():
-    classes = ["a", "b", "c", "d"]
-    board = from_board_id(classes, (3, 3), 0)
+    classes = [["a", "b", "c", "d"]] * 9
+    num_classes = [4] * 9
+    board = from_board_id(classes, 0)
     assert board == "a a a a a a a a a"
-    assert board_id([[0, 0, 0], [0, 0, 0], [0, 0, 0]], (3, 3), 4) == 0
+    assert board_id([[0, 0, 0], [0, 0, 0], [0, 0, 0]], num_classes) == 0
 
-    board = from_board_id(classes, (3, 3), 100068)
+    board = from_board_id(classes, 100068)
     assert board == "a b c d c b a c b"
-    assert board_id(to_2d([0, 1, 2, 3, 2, 1, 0, 2, 1], (3, 3)), (3, 3), 4) == 100068
+    assert board_id(to_2d([0, 1, 2, 3, 2, 1, 0, 2, 1], (3, 3)), num_classes) == 100068
 
-    board = from_board_id(classes, (3, 3), 4309)
+    board = from_board_id(classes, 4309)
     assert board == "b b b d a a b a a"
-    assert board_id(to_2d([1, 1, 1, 3, 0, 0, 1, 0, 0], (3, 3)), (3, 3), 4) == 4309
+    assert board_id(to_2d([1, 1, 1, 3, 0, 0, 1, 0, 0], (3, 3)), num_classes) == 4309
 
 
 def test_is_canonical_board_id33():
-    assert is_canonical_board_id(4, (3, 3), 0)
-    assert not is_canonical_board_id(4, (3, 3), 100068)
-    assert not is_canonical_board_id(4, (3, 3), 4309)
+    num_classes = [4] * 9
+    assert is_canonical_board_id(num_classes, (3, 3), 0)
+    assert not is_canonical_board_id(num_classes, (3, 3), 100068)
+    assert not is_canonical_board_id(num_classes, (3, 3), 4309)
 
 
 def test_best_34():
     best = "s i n d l a t e p e r s".split(" ")
-    classes = ["bdfgjvwxz", "aeiou", "lnrsy", "chkmpt"]
-    best_class = " ".join([next(c for c in classes if x in c) for x in best])
+    classes = [["bdfgjvwxz", "aeiou", "lnrsy", "chkmpt"]] * 12
+    num_classes = [4] * 12
+    best_class = " ".join([next(c for c in classes[0] if x in c) for x in best])
     assert (
         best_class
         == "lnrsy aeiou lnrsy bdfgjvwxz lnrsy aeiou chkmpt aeiou chkmpt aeiou lnrsy lnrsy"
     )
-    best_idxs = [next(i for i, c in enumerate(classes) if x in c) for x in best]
+    best_idxs = [next(i for i, c in enumerate(classes[0]) if x in c) for x in best]
     assert best_idxs == [2, 1, 2, 0, 2, 1, 3, 1, 3, 1, 2, 2]
     best_idxs2d = to_2d(best_idxs, (3, 4))
     assert best_idxs2d == [
@@ -50,11 +53,11 @@ def test_best_34():
         [2, 3, 2],  # NTR
         [0, 1, 2],  # DES
     ]
-    assert board_id(best_idxs2d, (3, 4), 4) == 10974758
-    assert from_board_id(classes, (3, 4), 10974758) == best_class
-    assert get_canonical_board_id(4, (3, 4), 10974758) == 2520743
+    assert board_id(best_idxs2d, num_classes) == 10974758
+    assert from_board_id(classes, 10974758) == best_class
+    assert get_canonical_board_id(num_classes, (3, 4), 10974758) == 2520743
 
-    canonical_best_class = from_board_id(classes, (3, 4), 2520743)
+    canonical_best_class = from_board_id(classes, 2520743)
     best_2d = to_2d(canonical_best_class.split(" "), (3, 4))
     assert best_2d == [
         ["chkmpt", "lnrsy", "lnrsy"],  # P L S

--- a/boggle/bucket_descent.py
+++ b/boggle/bucket_descent.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Try to find a good split of the letters into buckets.
 
+2: aeiosuy bcdfghjklmnpqrtvwxz (12656.0)
 3: aeijou bcdfgmpqvwxz hklnrsty (2689.8)
 4: aeiou bcfhpst qxyz dgjklmnrvw (849.9)
-5: aeiou bfgpst xyz djlmnrvw chkq (461.6)
+5: aejsv bcfgkmpt dhlnrw iou qxyz (437.5)
 
 I've been doing most of my analysis with this bucketing (which excludes q):
 4: bdfgjvwxz aeiou lnrsy chkmpt
@@ -88,7 +89,10 @@ def main():
 
     boards = [[random.randint(0, 25) for _ in range(w * h)] for _ in range(10)]
 
-    manual = "bdfgjvwxzq aeiou lnrsy chkmpt"
+    # manual = "bdfgjvwxzq aeiou lnrsy chkmpt"
+    # manual = "aeiou bcdfghjklmnpqrstvwxyz"
+    # manual = "aeiosuy bcdfghjklmnpqrtvwxz"
+    manual = "aeiou bfgpst xyz djlmnrvw chkq"
     manual_buckets = class_to_buckets(manual)
     # print(manual_buckets)
     # print(realize_bucket(manual_buckets))
@@ -96,14 +100,14 @@ def main():
     score = bucket_score(bb, manual_buckets, boards)
     print(f"Manual score: {score}")
 
-    for _ in range(5):
+    for _ in range(10):
         init = random_buckets(num_classes)
         print(f"Initial: {realize_bucket(init)}")
         score = bucket_score(bb, init, boards)
         print(f"Initial score: {score}")
 
         last_improvement = 0
-        for i in range(10000):
+        for i in range(20_000):
             new = mutate_buckets(init, num_classes)
             new_score = bucket_score(bb, new, boards)
             if new_score < score:


### PR DESCRIPTION
Closes #38

This has been on my list for a while. Rather than using the same three buckets for every cell, we can use more buckets in the middle and fewer in the corners. Hopefully this results in fewer total classes without producing any classes that are overwhelmingly hard to break (which is what happens if you go down to two classes for all cells).

I found good two bucket and five bucket splits using `bucket_descent`. Then I re-did a full 3x3 run and a partial 3x4 run using this bucketing:

```
'center:aejsv bcfgkmpt dhlnrw iou qxyz, edge:aeijou bcdfgmpqvwxz hklnrsty, corner:aeiosuy bcdfghjklmnpqrtvwxz'
```

- 3x3: Completes in 4m12s on a single thread. This is about 1/3 the time of my previous best, so making the boards bigger is very helpful here. This is 85x faster than the six hours that I [reported][1] in 2009.
- 3x4: On pace for 41.5h on a single thread (I let it go 11%), which is an improvement over 46h. So this is also helpful, but not nearly as much. Three buckets were already about right for 3x4 Boggle.

[1]: https://www.danvk.org/wp/2009-08-08/breaking-3x3-boggle/index.html#:~:text=six%20hours%20on%20a%20single%20machine