### PR TITLE
Colorful/minimal DOT renderings

### DIFF
--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -743,7 +743,7 @@ class EvalNode:
         )
         return f"""graph {{
     rankdir=LR;
-    splines="false";
+    nodesep=0.15;
     node [shape="rect" penwidth="0" style="rounded" fontname="Comic Sans MS"];
     {dot}
 }}

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -744,7 +744,7 @@ class EvalNode:
         return f"""graph {{
     rankdir=LR;
     splines="false";
-    node [shape="rect" penwidth="0"];
+    node [shape="rect" penwidth="0" style="rounded" fontname="Comic Sans MS"];
     {dot}
 }}
 """
@@ -768,7 +768,6 @@ class EvalNode:
             attrs += ' penwidth="1"'
         elif self.letter == CHOICE_NODE:
             me += f"_{self.cell}c"
-            # r1_1c0_1c0_0c [label="1" shape="rectangle" fillcolor="red" style="rounded, filled" fontcolor="black" penwidth="0"];
             color = DOT_FILL_COLORS[self.cell]
             attrs += f' style="rounded, filled" fillcolor="{color}"'
         else:
@@ -776,7 +775,8 @@ class EvalNode:
             me += f"_{self.cell}{letter}"
             attrs += ' penwidth="1"'
             # label = f"{self.cell}={letter}"
-            # if self.points:
+            if self.points and self.bound != self.points:
+                attrs += ' peripheries="2"'
             #     label += f" ({self.points})"
             #     if self.trie_node and lookup_table:
             #         word = lookup_table[self.trie_node]
@@ -806,9 +806,9 @@ class EvalNode:
         # print(f"{is_top_max=}, {all_choices=}")
         for i, (child_id, _) in enumerate(children):
             attrs = ""
-            if is_top_max and all_choices:
-                letter = cells[self.cell][i]
-                attrs = f' [label="{self.cell}={letter}"]'
+            # if is_top_max and all_choices:
+            #     letter = cells[self.cell][i]
+            #     attrs = f' [label="{self.cell}={letter}"]'
             dot.append(f"{me} -- {child_id}{attrs};")
         for _, child_dot in children:
             dot.append(child_dot)

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -800,9 +800,9 @@ class EvalNode:
             for i, child in enumerate(self.children)
             if child
         ]
-        all_choices = len(children) == len(self.children) and all(
-            c.letter == CHOICE_NODE for c in self.children
-        )
+        # all_choices = len(children) == len(self.children) and all(
+        #     c.letter == CHOICE_NODE for c in self.children
+        # )
 
         if self.letter != CHOICE_NODE and len(children) == 1 and not self.points:
             # A sum node with no points and only one child is just a placeholder.

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -744,7 +744,7 @@ class EvalNode:
         return f"""graph {{
     rankdir=LR;
     splines="false";
-    node [shape="rect"];
+    node [shape="rect" penwidth="0"];
     {dot}
 }}
 """
@@ -759,27 +759,29 @@ class EvalNode:
         # if self.letter != CHOICE_NODE:
         #     is_dupe = any_choice_collisions(self.children)
 
+        label = f"{self.bound}"
         attrs = ""
         if is_dupe:
             attrs = 'color="red"'
         if self.letter == ROOT_NODE:
             me += "r"
-            label = "ROOT"
+            attrs += ' penwidth="1"'
         elif self.letter == CHOICE_NODE:
             me += f"_{self.cell}c"
-            label = f"{self.cell} CH"
-            attrs += ' shape="oval"'
+            # r1_1c0_1c0_0c [label="1" shape="rectangle" fillcolor="red" style="rounded, filled" fontcolor="black" penwidth="0"];
+            color = DOT_FILL_COLORS[self.cell]
+            attrs += f' style="rounded, filled" fillcolor="{color}"'
         else:
             letter = cells[self.cell][self.letter]
             me += f"_{self.cell}{letter}"
-            label = f"{self.cell}={letter}"
-            if self.points:
-                label += f" ({self.points})"
-                attrs += ' peripheries="2"'
-                if self.trie_node and lookup_table:
-                    word = lookup_table[self.trie_node]
-                    label += f"\\nword={word}"
-        label += f"\\nbound={self.bound}"
+            attrs += ' penwidth="1"'
+            # label = f"{self.cell}={letter}"
+            # if self.points:
+            #     label += f" ({self.points})"
+            #     if self.trie_node and lookup_table:
+            #         word = lookup_table[self.trie_node]
+            #         label += f"\\nword={word}"
+        # label += f"\\nbound={self.bound}"
         cache[self] = me
         dot = [f'{me} [label="{label}"{attrs}];']
 
@@ -846,6 +848,26 @@ class EvalNode:
                     for child in self.children
                 ]
         return out
+
+
+DOT_FILL_COLORS = [
+    "LightSkyBlue",
+    "PaleGreen",
+    "LightSalmon",
+    "Khaki",
+    "Plum",
+    "Thistle",
+    "PeachPuff",
+    "Lavender",
+    "HoneyDew",
+    "MintCream",
+    "AliceBlue",
+    "LemonChiffon",
+    "MistyRose",
+    "PapayaWhip",
+    "BlanchedAlmond",
+    "LightCyan",
+]
 
 
 def bound_remaining_boards_help(

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -743,7 +743,7 @@ class EvalNode:
         )
         return f"""graph {{
     rankdir=LR;
-    nodesep=0.15;
+    nodesep=0.1;
     node [shape="rect" penwidth="0" style="rounded" fontname="Comic Sans MS"];
     {dot}
 }}

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -803,6 +803,12 @@ class EvalNode:
         all_choices = len(children) == len(self.children) and all(
             c.letter == CHOICE_NODE for c in self.children
         )
+
+        if self.letter != CHOICE_NODE and len(children) == 1 and not self.points:
+            # A sum node with no points and only one child is just a placeholder.
+            # Remove it from the graph to simplify the visualization.
+            return children[0]
+
         # print(f"{is_top_max=}, {all_choices=}")
         for i, (child_id, _) in enumerate(children):
             attrs = ""

--- a/boggle/make_dot.py
+++ b/boggle/make_dot.py
@@ -4,6 +4,7 @@
 import sys
 
 from boggle.dimensional_bogglers import LEN_TO_DIMS
+from boggle.orderly_tree_builder import OrderlyTreeBuilder
 from boggle.tree_builder import TreeBuilder
 from boggle.trie import make_py_trie
 
@@ -15,9 +16,10 @@ def main():
 
     cells = board.split(" ")
     dims = LEN_TO_DIMS[len(cells)]
-    etb = TreeBuilder(trie, dims)
+    # etb = TreeBuilder(trie, dims)
+    etb = OrderlyTreeBuilder(trie, dims)
     etb.ParseBoard(board)
-    t = etb.BuildTree(dedupe=False)
+    t = etb.BuildTree()  # dedupe=False)
     # assert_invariants(t, cells)
     # dedupe_subtrees(t)
 

--- a/boggle/make_dot.py
+++ b/boggle/make_dot.py
@@ -4,7 +4,7 @@
 import sys
 
 from boggle.dimensional_bogglers import LEN_TO_DIMS
-from boggle.eval_tree import TreeBuilder
+from boggle.tree_builder import TreeBuilder
 from boggle.trie import make_py_trie
 
 
@@ -17,24 +17,25 @@ def main():
     dims = LEN_TO_DIMS[len(cells)]
     etb = TreeBuilder(trie, dims)
     etb.ParseBoard(board)
-    t = etb.BuildTree(dedupe=True)
+    t = etb.BuildTree(dedupe=False)
     # assert_invariants(t, cells)
     # dedupe_subtrees(t)
 
     mark = 1
 
-    mark += 1
-    sys.stderr.write(
-        f"node count: {t.node_count()}, uniq={t.unique_node_count(mark)} bound={t.bound}\n"
-    )
     # t0 = t.children[0]
     # t0t = t0.children[0]
     # t = t0t
 
     with open("tree.dot", "w") as out:
         # out.write(t.to_dot(cells, max_depth=2))
-        out.write(t.to_dot(cells))
+        out.write(t.to_dot(cells, trie=trie))
         out.write("\n")
+
+    mark += 1
+    sys.stderr.write(
+        f"tree.dot node count: {t.node_count()}, uniq={t.unique_node_count(mark)} bound={t.bound}\n"
+    )
 
     for i, cell in enumerate(lift_cells):
         mark += 1

--- a/boggle/make_dot.py
+++ b/boggle/make_dot.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 
+import argparse
 import sys
 
+from boggle.args import add_standard_args, get_trie_from_args
 from boggle.dimensional_bogglers import LEN_TO_DIMS
 from boggle.orderly_tree_builder import OrderlyTreeBuilder
 from boggle.tree_builder import TreeBuilder
@@ -10,14 +12,34 @@ from boggle.trie import make_py_trie
 
 
 def main():
-    trie = make_py_trie("wordlists/enable2k.txt")
-    (board, *lift_cell_strs) = sys.argv[1:]
-    lift_cells = [int(s) for s in lift_cell_strs]
+    parser = argparse.ArgumentParser(
+        prog="DOT renderer",
+        description="Visualize what's going on with those trees.",
+    )
+    # TODO: don't set size, we just need the dictionary
+    add_standard_args(parser)
+    parser.add_argument(
+        "--tree_builder",
+        choices=("natural", "orderly"),
+        default="orderly",
+        help="Tree builder to use.",
+    )
+    parser.add_argument(
+        "--compress", action="store_true", help="Compress EvalTree while lifting"
+    )
+    parser.add_argument("board", type=str, help="Board class to render.")
+    parser.add_argument("lift_cells", nargs="*", help="Sequence of cells to lift")
+    args = parser.parse_args()
+    trie = make_py_trie(args.dictionary)
+    board = args.board
+    lift_cells = [int(s) for s in args.lift_cells]
 
     cells = board.split(" ")
     dims = LEN_TO_DIMS[len(cells)]
-    # etb = TreeBuilder(trie, dims)
-    etb = OrderlyTreeBuilder(trie, dims)
+    if args.tree_builder == "natural":
+        etb = TreeBuilder(trie, dims)
+    else:
+        etb = OrderlyTreeBuilder(trie, dims)
     etb.ParseBoard(board)
     t = etb.BuildTree()  # dedupe=False)
     # assert_invariants(t, cells)

--- a/boggle/make_dot.py
+++ b/boggle/make_dot.py
@@ -4,7 +4,7 @@
 import argparse
 import sys
 
-from boggle.args import add_standard_args, get_trie_from_args
+from boggle.args import add_standard_args
 from boggle.dimensional_bogglers import LEN_TO_DIMS
 from boggle.orderly_tree_builder import OrderlyTreeBuilder
 from boggle.tree_builder import TreeBuilder

--- a/boggle/make_dot.py
+++ b/boggle/make_dot.py
@@ -40,7 +40,7 @@ def main():
     for i, cell in enumerate(lift_cells):
         mark += 1
         t = t.lift_choice(
-            cell, len(cells[cell]), None, mark, dedupe=True, compress=False
+            cell, len(cells[cell]), None, mark, dedupe=False, compress=True
         )
         mark += 1
         sys.stderr.write(

--- a/boggle/split_order.py
+++ b/boggle/split_order.py
@@ -52,6 +52,7 @@ assert len(set(SPLIT_ORDER_44)) == 16
 
 SPLIT_ORDER = {
     (2, 2): (0, 1, 2, 3),
+    (2, 3): (0, 1, 2, 3, 4, 5),
     (3, 3): SPLIT_ORDER_33,
     (3, 4): SPLIT_ORDER_34,
     (4, 4): SPLIT_ORDER_44,


### PR DESCRIPTION
Code used for generating the [orderly trees blog post][1]. I've left the old code in place but commented out in case I need it again.

New style drops everything except the bound. Cell numbers are represented through a GPT-chosen color palette:

![image](https://github.com/user-attachments/assets/2c32d966-9df5-40d0-a256-2e4e5c80b38a)

Compare with the previous tree diagram, which contains a lot more information but is much harder to understand at a glance:

![image](https://github.com/user-attachments/assets/3f70d579-56b2-4a93-aa37-1c75a264fcdf)

[1]: https://www.danvk.org/2025/02/21/orderly-boggle.html