### PR TITLE
Optimize orderly tree building

### DIFF
--- a/boggle/lift_to_break.py
+++ b/boggle/lift_to_break.py
@@ -2,6 +2,7 @@
 """Break a 2x2 board class via successive lifting."""
 
 import argparse
+import time
 
 from boggle.args import add_standard_args, get_trie_from_args
 from boggle.breaker import SPLIT_ORDER
@@ -54,7 +55,10 @@ def main():
 
     arena = etb.create_arena()
     assert etb.ParseBoard(board)
+    start_s = time.time()
     t = etb.BuildTree(arena, dedupe=args.dedupe)
+    elapsed_s = time.time() - start_s
+    print(f"{elapsed_s:.02f}s BuildTree: ", end="")
     print(tree_stats(t))
     # t.compress_in_place()
     # print(f"c -> {tree_stats(t)}")

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -1,4 +1,5 @@
 import argparse
+import time
 
 from boggle.args import add_standard_args, get_trie_from_args
 from boggle.board_class_boggler import BoardClassBoggler
@@ -109,16 +110,20 @@ def main():
     # e_arena = etb.create_arena()
     # classic_tree = etb.BuildTree(e_arena, dedupe=True)
 
-    # otb = OrderlyTreeBuilder(trie, dims)
-    otb = OrderlyTreeBuilders[dims](trie)
+    if args.python:
+        otb = OrderlyTreeBuilder(trie, dims)
+    else:
+        otb = OrderlyTreeBuilders[dims](trie)
     o_arena = otb.create_arena()
     assert otb.ParseBoard(board)
+    start_s = time.time()
     orderly_tree = otb.BuildTree(o_arena)
+    elapsed_s = time.time() - start_s
 
     # print("EvalTreeBuilder:    ", end="")
     # print(tree_stats(classic_tree))
 
-    print("OrderlyTreeBuilder: ", end="")
+    print(f"{elapsed_s:.02f}s OrderlyTreeBuilder: ", end="")
     print(tree_stats(orderly_tree))
 
     global mark
@@ -127,14 +132,18 @@ def main():
     for cell in splits[: args.num_lifts]:
         print(f"lift {cell}")
         mark += 1
+        start_s = time.time()
         t = t.lift_choice(
             cell, len(cells[cell]), o_arena, mark, dedupe=True, compress=True
         )
+        elapsed_s = time.time() - start_s
         if t.bound <= args.cutoff:
-            print(f"Fully broken! {t.bound} <= {args.cutoff} {tree_stats(t)}")
+            print(
+                f"{elapsed_s:.02f}s Fully broken! {t.bound} <= {args.cutoff} {tree_stats(t)}"
+            )
             break
         t.filter_below_threshold(args.cutoff)
-        print(f"f -> {tree_stats(t)}")
+        print(f"{elapsed_s:.02f}s f -> {tree_stats(t)}")
 
 
 if __name__ == "__main__":

--- a/cpp/board_class_boggler.h
+++ b/cpp/board_class_boggler.h
@@ -89,6 +89,7 @@ const char* BoardClassBoggler<M, N>::as_string() {
 // Generated via:
 // poetry run python -m boggle.neighbors
 // First entry is the number of neighbors in the list.
+// TODO: make these null-terminated rather than "pascal arrays" (may be faster).
 
 // 2x2
 template<>

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -172,26 +172,6 @@ void EvalNode::SetComputedFields(vector<int>& num_letters) {
   }
 }
 
-void EvalNode::SetChoiceMask(vector<int>& num_letters) {
-  for (auto c : children_) {
-    if (c) {
-      ((EvalNode*)c)->SetChoiceMask(num_letters);
-    }
-  }
-
-  if (letter_ == CHOICE_NODE) {
-    choice_mask_ = num_letters[cell_] > 1 ? (1 << cell_) : 0;
-  } else {
-    choice_mask_ = 0;
-  }
-
-  for (auto c : children_) {
-    if (c) {
-      choice_mask_ |= c->choice_mask_;
-    }
-  }
-}
-
 const EvalNode* SqueezeChoiceChild(const EvalNode* child);
 bool SqueezeSumNodeInPlace(EvalNode* node, EvalNodeArena& arena, bool should_merge);
 

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -16,7 +16,7 @@ inline bool SortByLetter(const EvalNode* a, const EvalNode* b) {
   return a->letter_ < b->letter_;
 }
 
-void EvalNode::AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena) {\
+void EvalNode::AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena) {
   if (!num_choices) {
     points_ += points;
     return;

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -17,7 +17,6 @@ inline bool SortByLetter(const EvalNode* a, const EvalNode* b) {
 }
 
 void EvalNode::AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena) {\
-  // TODO: convert this to a loop, once you encounter a missing node you no longer need to search.
   if (!num_choices) {
     points_ += points;
     return;
@@ -55,7 +54,6 @@ void EvalNode::AddWordWork(int num_choices, pair<int, int>* choices, int points,
     letter_child->cell_ = cell;
     letter_child->letter_ = letter;
     arena.AddNode(letter_child);
-    // TODO: special-case adding to a one-element vector
     choice_child->children_.push_back(letter_child);
     sort(choice_child->children_.begin(), choice_child->children_.end(), SortByLetter);
   }

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -16,7 +16,8 @@ inline bool SortByLetter(const EvalNode* a, const EvalNode* b) {
   return a->letter_ < b->letter_;
 }
 
-void EvalNode::AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena) {
+void EvalNode::AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena) {\
+  // TODO: convert this to a loop, once you encounter a missing node you no longer need to search.
   if (!num_choices) {
     points_ += points;
     return;
@@ -27,7 +28,6 @@ void EvalNode::AddWordWork(int num_choices, pair<int, int>* choices, int points,
   choices++;
   num_choices--;
 
-  // See Python for optimization TODOs
   EvalNode* choice_child = NULL;
   for (auto c : children_) {
     if (c->cell_ == cell) {
@@ -55,6 +55,7 @@ void EvalNode::AddWordWork(int num_choices, pair<int, int>* choices, int points,
     letter_child->cell_ = cell;
     letter_child->letter_ = letter;
     arena.AddNode(letter_child);
+    // TODO: special-case adding to a one-element vector
     choice_child->children_.push_back(letter_child);
     sort(choice_child->children_.begin(), choice_child->children_.end(), SortByLetter);
   }

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -68,7 +68,7 @@ class EvalNode {
   virtual ~EvalNode() {}
 
   void AddWord(vector<pair<int, int>> choices, int points, EvalNodeArena& arena);
-  void AddWordWork(int num_choices, pair<int, int>* choices, int points, EvalNodeArena& arena);
+  void AddWordWork(int num_choices, pair<int, int>* choices, const int* num_letters, int points, EvalNodeArena& arena);
 
   bool StructuralEq(const EvalNode& other) const;
   void PrintJSON() const;

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -74,6 +74,7 @@ class EvalNode {
   void PrintJSON() const;
 
   void SetComputedFields(vector<int>& num_letters);
+  void SetChoiceMask(vector<int>& num_letters);
 
   const EvalNode*
   LiftChoice(int cell, int num_lets, EvalNodeArena& arena, uint32_t mark, bool dedupe=false, bool compress=false) const;

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -74,7 +74,6 @@ class EvalNode {
   void PrintJSON() const;
 
   void SetComputedFields(vector<int>& num_letters);
-  void SetChoiceMask(vector<int>& num_letters);
 
   const EvalNode*
   LiftChoice(int cell, int num_lets, EvalNodeArena& arena, uint32_t mark, bool dedupe=false, bool compress=false) const;

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -33,7 +33,6 @@ class OrderlyTreeBuilder : public BoardClassBoggler<M, N> {
 
  private:
   EvalNode* root_;
-  vector<int> num_letters_;
   int cell_to_order_[M*N];
   pair<int, int> choices_[M*N];
   pair<int, int> orderly_choices_[M*N];
@@ -51,16 +50,15 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
   root_->points_ = 0;
   used_ = 0;
 
-  num_letters_.resize(M*N);
-  for (int i = 0; i < M*N; i++) {
-    num_letters_[i] = strlen(bd_[i]);
-  }
-
   for (int cell = 0; cell < M * N; cell++) {
     DoAllDescents(cell, 0, 0, dict_, arena);
   }
 
-  root_->SetComputedFields(num_letters_);
+  vector<int> num_letters(M*N, 0);
+  for (int i = 0; i < M*N; i++) {
+    num_letters[i] = strlen(bd_[i]);
+  }
+  root_->SetComputedFields(num_letters);
   auto root = root_;
   root_ = NULL;
   arena.AddNode(root);
@@ -71,7 +69,6 @@ template<int M, int N>
 void OrderlyTreeBuilder<M, N>::DoAllDescents(int cell, int n, int length, Trie* t, EvalNodeArena& arena) {
   choices_[n] = {cell, 0};
 
-  // int n_chars = num_letters_[cell];
   char* c = &bd_[cell][0];
   int j = 0;
   while (*c) {

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -60,7 +60,6 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
     DoAllDescents(cell, 0, 0, dict_, arena);
   }
 
-  // root_->SetChoiceMask(num_letters);
   auto root = root_;
   root_ = NULL;
   arena.AddNode(root);
@@ -113,6 +112,5 @@ void OrderlyTreeBuilder<M, N>::DoDFS(int i, int n, int length, Trie* t, EvalNode
 
   used_ ^= (1 << i);
 }
-
 
 #endif // ORDERLY_TREE_BUILDER_H

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -36,6 +36,7 @@ class OrderlyTreeBuilder : public BoardClassBoggler<M, N> {
   bool dedupe_;
   int cell_to_order_[M*N];
   pair<int, int> choices_[M*N];
+  pair<int, int> orderly_choices_[M*N];
 
   void DoAllDescents(int cell, int n, int length, Trie* t, EvalNodeArena& arena);
   void DoDFS(int cell, int n, int length, Trie* t, EvalNodeArena& arena);
@@ -96,15 +97,17 @@ void OrderlyTreeBuilder<M, N>::DoDFS(int i, int n, int length, Trie* t, EvalNode
   if (t->IsWord()) {
     auto word_score = kWordScores[length];
 
-    vector<pair<int, int>> orderly_choices;
-    for (int j = 0; j < n; j++) {
-      orderly_choices.push_back(choices_[j]);
-    }
-    // TODO: "this" capture could be avoided
-    sort(orderly_choices.begin(), orderly_choices.end(), [this](const pair<int, int>& a, const pair<int, int>& b) {
+    pair<int, int>* orderly_ptr = &orderly_choices_[0];
+    memcpy(orderly_ptr, &choices_[0], n);
+    sort(orderly_ptr, orderly_ptr + n, [this](const pair<int, int>& a, const pair<int, int>& b) {
       return cell_to_order_[a.first] < cell_to_order_[b.first];
     });
-    root_->AddWord(orderly_choices, word_score, arena);
+    cout << "Add";
+    for (int i = 0; i < n; i++) {
+      cout << " " << (int)orderly_choices_[i].first << ":" << (int)orderly_choices_[i].second;
+    }
+    cout << endl;
+    root_->AddWordWork(n, orderly_choices_, word_score, arena);
   }
 
   used_ ^= (1 << i);

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -101,6 +101,9 @@ void OrderlyTreeBuilder<M, N>::DoDFS(int i, int n, int length, Trie* t, EvalNode
   if (t->IsWord()) {
     auto word_score = kWordScores[length];
 
+    // TODO: track current letter for each cell in a plain array.
+    //       Use used_ bit mask to track which ones are relevant.
+    //       map these through cell_to_order to avoid the need for sorting or copying.
     pair<int, int>* orderly_ptr = &orderly_choices_[0];
     memcpy(orderly_ptr, &choices_[0], n * sizeof(pair<int, int>));
     sort(orderly_ptr, orderly_ptr + n, [this](const pair<int, int>& a, const pair<int, int>& b) {

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -98,15 +98,13 @@ void OrderlyTreeBuilder<M, N>::DoDFS(int i, int n, int length, Trie* t, EvalNode
     auto word_score = kWordScores[length];
 
     pair<int, int>* orderly_ptr = &orderly_choices_[0];
-    memcpy(orderly_ptr, &choices_[0], n);
+    // for (int i = 0; i < n; i++) {
+    //   orderly_choices_[i] = choices_[i];
+    // }
+    memcpy(orderly_ptr, &choices_[0], n * sizeof(pair<int, int>));
     sort(orderly_ptr, orderly_ptr + n, [this](const pair<int, int>& a, const pair<int, int>& b) {
       return cell_to_order_[a.first] < cell_to_order_[b.first];
     });
-    cout << "Add";
-    for (int i = 0; i < n; i++) {
-      cout << " " << (int)orderly_choices_[i].first << ":" << (int)orderly_choices_[i].second;
-    }
-    cout << endl;
     root_->AddWordWork(n, orderly_choices_, word_score, arena);
   }
 

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -49,6 +49,7 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
   root_->letter_ = EvalNode::ROOT_NODE;
   root_->cell_ = 0; // irrelevant
   root_->points_ = 0;
+  root_->bound_ = 0;
   used_ = 0;
 
   num_letters_.resize(M*N);

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -34,6 +34,7 @@ class OrderlyTreeBuilder : public BoardClassBoggler<M, N> {
  private:
   EvalNode* root_;
   int cell_to_order_[M*N];
+  vector<int> num_letters_;
   pair<int, int> choices_[M*N];
   pair<int, int> orderly_choices_[M*N];
 
@@ -50,15 +51,16 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
   root_->points_ = 0;
   used_ = 0;
 
+  num_letters_.resize(M*N);
+  for (int i = 0; i < M*N; i++) {
+    num_letters_[i] = strlen(bd_[i]);
+  }
+
   for (int cell = 0; cell < M * N; cell++) {
     DoAllDescents(cell, 0, 0, dict_, arena);
   }
 
-  vector<int> num_letters(M*N, 0);
-  for (int i = 0; i < M*N; i++) {
-    num_letters[i] = strlen(bd_[i]);
-  }
-  root_->SetChoiceMask(num_letters);
+  // root_->SetChoiceMask(num_letters);
   auto root = root_;
   root_ = NULL;
   arena.AddNode(root);
@@ -106,7 +108,7 @@ void OrderlyTreeBuilder<M, N>::DoDFS(int i, int n, int length, Trie* t, EvalNode
     sort(orderly_ptr, orderly_ptr + n, [this](const pair<int, int>& a, const pair<int, int>& b) {
       return cell_to_order_[a.first] < cell_to_order_[b.first];
     });
-    root_->AddWordWork(n, orderly_choices_, word_score, arena);
+    root_->AddWordWork(n, orderly_choices_, num_letters_.data(), word_score, arena);
   }
 
   used_ ^= (1 << i);

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -58,7 +58,7 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
   for (int i = 0; i < M*N; i++) {
     num_letters[i] = strlen(bd_[i]);
   }
-  root_->SetComputedFields(num_letters);
+  root_->SetChoiceMask(num_letters);
   auto root = root_;
   root_ = NULL;
   arena.AddNode(root);


### PR DESCRIPTION
See #18

Orderly tree building proved much harder to optimize than I'd expected. Almost none of my ideas worked.

Things that did help:

- Pre-allocating the `order_choices_` array (~10% speedup)
- Using `memcpy` to fill it (~2% speedup)
- Iterating over the characters in each cell C-style, rather than calling `strlen` (also 2-3% speedup).
- Setting `bound` and `choice_mask` as words are added instead of in a second pass (~15% speedup).

Things that did not help:

- Any optimization to `AddWord`: changing the recursion to a loop, breaking out of the loop once we're in an allocation loop, special-casing keeping a two element vector sorted.
- Making `cell_to_order_` a static constant.
- Making the `sort` comparison function in `OrderlyTreeBuilder<M, N>::DoDFS` a standalone function without a capture.

So overall this is a ~30% speedup to `BuildTree`, which translates into a ~20% speedup on my 50-board 3x4 benchmark.