### PR TITLE
OrderlyBound: specialized BoundRemainingBoards for orderly trees

### DIFF
--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -123,8 +123,11 @@ class HybridTreeBreaker:
         self.orig_reps_ = self.details_.num_reps = self.etb.NumReps()
         start_time_s = time.time()
         arena = self.etb.create_arena()
-        tree = self.etb.BuildTree(arena, dedupe=False)
-        num_nodes = arena.num_nodes()
+        tree = self.etb.BuildTree(arena)
+        if isinstance(tree, EvalNode):
+            num_nodes = tree.node_count()
+        else:
+            num_nodes = arena.num_nodes()
         if self.log_breaker_progress:
             self.mark += 1
             print(

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -238,7 +238,7 @@ class HybridTreeBreaker:
         for board in it:
             n_expanded += 1
             true_score = self.boggler.score(board)
-            print(f"{board}: {tree.bound} -> {true_score}")
+            # print(f"{board}: {tree.bound} -> {true_score}")
             if true_score >= self.best_score:
                 print(f"Unable to break board: {board} {true_score}")
                 self.details_.failures.append(board)

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -212,7 +212,9 @@ class HybridTreeBreaker:
             remaining_cells = [
                 cell for cell in self.split_order if cell not in forced_cells
             ]
-            score_boards = tree.orderly_bound(500, self.cells, remaining_cells, seq)
+            score_boards = t.orderly_bound(
+                self.best_score, self.cells, remaining_cells, seq
+            )
             # print(time.time() - start_s, seq, tree.bound, this_failures)
             boards_to_test += [board for _score, board in score_boards]
         elapsed_s = time.time() - start_s

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -208,14 +208,16 @@ class HybridTreeBreaker:
             self.details_.free_time_s = time.time() - start_s
         start_s = time.time()
         # TODO: move this call into bound_remaining_boards()
-        tree.set_choice_point_mask(self.num_letters)
+        # tree.set_choice_point_mask(self.num_letters)
         elapsed_s = time.time() - start_s
         start_s = time.time()
-        boards_to_test = tree.bound_remaining_boards(
-            self.cells, self.best_score, self.split_order
-        )
+        # boards_to_test = tree.bound_remaining_boards(
+        #     self.cells, self.best_score, self.split_order
+        # )
+        remainder = tree.orderly_bound(self.best_score, self.cells, self.split_order)
         elapsed_s = time.time() - start_s
         self.details_.secs_by_level[level] += elapsed_s
+        boards_to_test = [board for _score, board in remainder]
 
         if not boards_to_test:
             return

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -238,7 +238,7 @@ class HybridTreeBreaker:
         for board in it:
             n_expanded += 1
             true_score = self.boggler.score(board)
-            # print(choices, board, tree.bound, "->", true_score)
+            print(f"{board}: {tree.bound} -> {true_score}")
             if true_score >= self.best_score:
                 print(f"Unable to break board: {board} {true_score}")
                 self.details_.failures.append(board)

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -608,10 +608,12 @@ class EvalNode:
             next_to_split = split_order[num_splits]
             stack_top = [len(stack) for stack in stacks]
             # print(f"{indent}{stack_top=}")
+            base_sums = [*stack_sums]
             for letter in range(0, num_letters[next_to_split]):
                 # print(f"{indent}{next_to_split}={letter}")
-                # TODO: don't reallocate this
-                next_sums = [*stack_sums]
+                if letter > 0:
+                    for i, v in enumerate(base_sums):
+                        stack_sums[i] = v
                 choices.append((next_to_split, letter))
                 points = base_points
                 for node in stacks[next_to_split]:
@@ -622,9 +624,9 @@ class EvalNode:
                             letter_node = n
                             break
                     if letter_node:
-                        points += advance(letter_node, next_sums)
+                        points += advance(letter_node, stack_sums)
 
-                rec(points, num_splits + 1, next_sums)
+                rec(points, num_splits + 1, stack_sums)
                 # reset the stacks
                 choices.pop()
                 # TODO: track a "top" of each stack and leave the rest as garbage

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -563,12 +563,14 @@ class EvalNode:
         stacks = [[] for _ in num_letters]
         choices = []  # for tracking unbreakable boards
         failures: list[str] = []
+        # max_lens: list[int] = [0] * len(stacks)
 
         def advance(node: Self):
             assert node.letter != CHOICE_NODE
             for child in node.children:
                 assert child.letter == CHOICE_NODE
                 stacks[child.cell].append(child)
+                # max_lens[child.cell] = max(max_lens[child.cell], len(stacks[child.cell]))
             return node.points
 
         def record_failure(bound: int):
@@ -576,8 +578,8 @@ class EvalNode:
             for cell, letter in choices:
                 bd[cell] = cells[cell][letter]
             board = "".join(bd)
-            indent = "  " * len(num_letters)
-            print(f"{indent}unbreakable board! {bound} {board} {choices=}")
+            # indent = "  " * len(num_letters)
+            # print(f"{indent}unbreakable board! {bound} {board} {choices=}")
             nonlocal failures
             failures.append((bound, board))
 
@@ -587,8 +589,8 @@ class EvalNode:
                 sum(node.bound for node in stacks[cell])
                 for cell in split_order[num_splits:]
             )
-            indent = "  " * num_splits
-            print(f"{indent}{num_splits=} {base_points=} {bound=}")
+            # indent = "  " * num_splits
+            # print(f"{indent}{num_splits=} {base_points=} {bound=}")
             if bound <= cutoff:
                 return True  # done!
             if num_splits == len(split_order):
@@ -598,9 +600,9 @@ class EvalNode:
             # need to advance; try each possibility in turn.
             next_to_split = split_order[num_splits]
             stack_top = [len(stack) for stack in stacks]
-            print(f"{indent}{stack_top=}")
+            # print(f"{indent}{stack_top=}")
             for letter in range(0, num_letters[next_to_split]):
-                print(f"{indent}{next_to_split}={letter}")
+                # print(f"{indent}{next_to_split}={letter}")
                 choices.append((next_to_split, letter))
                 points = base_points
                 for node in stacks[next_to_split]:
@@ -621,6 +623,7 @@ class EvalNode:
 
         assert advance(self) == 0
         rec(0, 0)
+        # print(f"{max_lens=}")
         return failures
 
     # --- Methods below here are only for testing / debugging and may not have C++ equivalents. ---

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -231,6 +231,7 @@ class EvalNode:
         self,
         cell: int,
         num_lets: int,
+        # TODO: make these required params
         arena=None,
         mark=None,
         dedupe=False,
@@ -566,7 +567,13 @@ class EvalNode:
             if c:
                 self.choice_mask |= c.choice_mask
 
-    def orderly_bound(self, cutoff: int, cells: list[str], split_order: Sequence[int]):
+    def orderly_bound(
+        self,
+        cutoff: int,
+        cells: list[str],
+        split_order: Sequence[int],
+        preset_cells: Sequence[tuple[int, int]] = None,
+    ):
         num_letters = [len(cell) for cell in cells]
         stacks = [[] for _ in num_letters]
         choices = []  # for tracking unbreakable boards
@@ -584,6 +591,8 @@ class EvalNode:
 
         def record_failure(bound: int):
             bd = [None] * len(num_letters)
+            for cell, letter in preset_cells or []:
+                bd[cell] = cells[cell][letter]
             for cell, letter in choices:
                 bd[cell] = cells[cell][letter]
             board = "".join(bd)
@@ -599,10 +608,10 @@ class EvalNode:
             # indent = "  " * num_splits
             # print(f"{indent}{num_splits=} {base_points=} {bound=}")
             if bound <= cutoff:
-                return True  # done!
+                return  # done!
             if num_splits == len(split_order):
                 record_failure(bound)
-                return False
+                return
 
             # need to advance; try each possibility in turn.
             next_to_split = split_order[num_splits]

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -614,6 +614,9 @@ class EvalNode:
                 if letter > 0:
                     for i, v in enumerate(base_sums):
                         stack_sums[i] = v
+                    # TODO: track a "top" of each stack and leave the rest as garbage
+                    for i, length in enumerate(stack_top):
+                        stacks[i] = stacks[i][:length]
                 choices.append((next_to_split, letter))
                 points = base_points
                 for node in stacks[next_to_split]:
@@ -629,9 +632,6 @@ class EvalNode:
                 rec(points, num_splits + 1, stack_sums)
                 # reset the stacks
                 choices.pop()
-                # TODO: track a "top" of each stack and leave the rest as garbage
-                for i, length in enumerate(stack_top):
-                    stacks[i] = stacks[i][:length]
 
         sums = [0] * len(num_letters)
         assert advance(self, sums) == 0

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -572,7 +572,7 @@ class EvalNode:
         cutoff: int,
         cells: list[str],
         split_order: Sequence[int],
-        preset_cells: Sequence[tuple[int, int]] = None,
+        preset_cells: Sequence[tuple[int, int]],
     ):
         num_letters = [len(cell) for cell in cells]
         stacks = [[] for _ in num_letters]
@@ -591,7 +591,7 @@ class EvalNode:
 
         def record_failure(bound: int):
             bd = [None] * len(num_letters)
-            for cell, letter in preset_cells or []:
+            for cell, letter in preset_cells:
                 bd[cell] = cells[cell][letter]
             for cell, letter in choices:
                 bd[cell] = cells[cell][letter]

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -643,8 +643,8 @@ class EvalNode:
                 choices.pop()
 
         sums = [0] * len(num_letters)
-        assert advance(self, sums) == 0
-        rec(0, 0, sums)
+        base_points = advance(self, sums)
+        rec(base_points, 0, sums)
         # print(f"{max_lens=}")
         return failures
 

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -558,11 +558,11 @@ class EvalNode:
             if c:
                 self.choice_mask |= c.choice_mask
 
-    def orderly_bound(
-        self, cutoff: int, num_letters: Sequence[int], split_order: Sequence[int]
-    ):
+    def orderly_bound(self, cutoff: int, cells: list[str], split_order: Sequence[int]):
+        num_letters = [len(cell) for cell in cells]
         stacks = [[] for _ in num_letters]
         choices = []  # for tracking unbreakable boards
+        failures: list[str] = []
 
         def advance(node: Self):
             assert node.letter != CHOICE_NODE
@@ -582,7 +582,13 @@ class EvalNode:
             if bound < cutoff:
                 return True  # done!
             if num_splits == len(split_order):
-                print(f"{indent}unbreakable board! {choices=}")
+                bd = [None] * len(num_letters)
+                for cell, letter in choices:
+                    bd[cell] = cells[cell][letter]
+                board = "".join(bd)
+                print(f"{indent}unbreakable board! {board} {choices=}")
+                nonlocal failures
+                failures.append(board)
                 return False  # have an unbreakable board; TODO: which board?
 
             # need to advance; try each possibility in turn.
@@ -610,7 +616,8 @@ class EvalNode:
                     stacks[i] = stacks[i][:length]
 
         advance(self)
-        return rec(0, 0)
+        rec(0, 0)
+        return failures
 
     # --- Methods below here are only for testing / debugging and may not have C++ equivalents. ---
 

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -873,6 +873,9 @@ class EvalNode:
         # print(f"{is_top_max=}, {all_choices=}")
         for i, (child_id, _) in enumerate(children):
             attrs = ""
+            if self.letter == CHOICE_NODE and len(children) < len(cells[self.cell]):
+                # incomplete set of choices; label them for clarity.
+                attrs = f' [label="{self.children[i].letter}"]'
             # if is_top_max and all_choices:
             #     letter = cells[self.cell][i]
             #     attrs = f' [label="{self.cell}={letter}"]'

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -571,6 +571,16 @@ class EvalNode:
                 stacks[child.cell].append(child)
             return node.points
 
+        def record_failure(bound: int):
+            bd = [None] * len(num_letters)
+            for cell, letter in choices:
+                bd[cell] = cells[cell][letter]
+            board = "".join(bd)
+            indent = "  " * len(num_letters)
+            print(f"{indent}unbreakable board! {bound} {board} {choices=}")
+            nonlocal failures
+            failures.append((bound, board))
+
         def rec(base_points: int, num_splits: int):
             # TODO: this could be much more efficient; track a bound to the top of each stack.
             bound = base_points + sum(
@@ -579,17 +589,11 @@ class EvalNode:
             )
             indent = "  " * num_splits
             print(f"{indent}{num_splits=} {base_points=} {bound=}")
-            if bound < cutoff:
+            if bound <= cutoff:
                 return True  # done!
             if num_splits == len(split_order):
-                bd = [None] * len(num_letters)
-                for cell, letter in choices:
-                    bd[cell] = cells[cell][letter]
-                board = "".join(bd)
-                print(f"{indent}unbreakable board! {board} {choices=}")
-                nonlocal failures
-                failures.append(board)
-                return False  # have an unbreakable board; TODO: which board?
+                record_failure(bound)
+                return False
 
             # need to advance; try each possibility in turn.
             next_to_split = split_order[num_splits]
@@ -615,7 +619,7 @@ class EvalNode:
                 for i, length in enumerate(stack_top):
                     stacks[i] = stacks[i][:length]
 
-        advance(self)
+        assert advance(self) == 0
         rec(0, 0)
         return failures
 

--- a/boggle/lift_to_break.py
+++ b/boggle/lift_to_break.py
@@ -108,7 +108,7 @@ def main():
     if t.bound > cutoff:
         print("Unbroken boards:")
         for max_t, path in t.max_subtrees():
-            board = "".join(cells[cell][letter] for cell, letter in path)
+            board = "".join(cells[cell][letter] for cell, letter in reversed(path))
             print(f"{max_t.bound} {board}")
 
 

--- a/boggle/lift_to_break.py
+++ b/boggle/lift_to_break.py
@@ -105,6 +105,12 @@ def main():
 
     PrintEvalTreeCounts()
 
+    if t.bound > cutoff:
+        print("Unbroken boards:")
+        for max_t, path in t.max_subtrees():
+            board = "".join(cells[cell][letter] for cell, letter in path)
+            print(f"{max_t.bound} {board}")
+
 
 if __name__ == "__main__":
     main()

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -14,10 +14,10 @@ from boggle.split_order import SPLIT_ORDER
 from boggle.trie import PyTrie
 
 
-# TODO: decide if this really needs to inherit PyBucketBoggler
 class OrderlyTreeBuilder(BoardClassBoggler):
     cell_to_order: dict[int, int]
     root: EvalNode
+    cell_counts: list[int]
 
     def __init__(self, trie: PyTrie, dims: tuple[int, int] = (3, 3)):
         super().__init__(trie, dims)
@@ -30,6 +30,7 @@ class OrderlyTreeBuilder(BoardClassBoggler):
         root.points = 0
         self.root = root
         self.used_ = 0
+        self.cell_counts = [0] * len(self.bd_)
 
         for cell in range(len(self.bd_)):
             self.DoAllDescents(cell, 0, self.trie_, [], arena)
@@ -77,7 +78,7 @@ class OrderlyTreeBuilder(BoardClassBoggler):
         if t.IsWord():
             word_score = SCORES[length]
             orderly_choices = [*sorted(choices, key=lambda c: self.cell_to_order[c[0]])]
-            self.root.add_word(orderly_choices, word_score, arena)
+            self.root.add_word(orderly_choices, word_score, arena, self.cell_counts)
 
         self.used_ ^= 1 << cell
 

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -174,6 +174,23 @@ def test_lift_and_bound(make_trie, get_tree_builder):
         # print(time.time() - start_s, seq, tree.bound, this_failures)
         failures += this_failures
 
+    cell1 = order.pop(0)
+    mark += 1
+    t = t.lift_choice(
+        cell1, len(cells[cell1]), arena, mark, dedupe=False, compress=True
+    )
+    assert t.bound == 714
+    assert t.letter == CHOICE_NODE
+    assert t.cell == cell1
+    assert len(t.children) == len(cells[cell1])
+
+    failures = []
+    for tree, seq in t.max_subtrees():
+        start_s = time.time()
+        this_failures = tree.orderly_bound(500, cells, order, seq)
+        print(time.time() - start_s, seq, tree.bound, this_failures)
+        failures += this_failures
+
     # (same as test_orderly_bound33)
     assert failures == snapshot([(512, "stsaseblt")])
     # assert False

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -127,4 +127,3 @@ def test_orderly_bound33():
     # print(time.time() - start_s)
     # break_all reports 889 points for this board, but ibucket_solver reports 512
     assert failures == snapshot([(512, "stsaseblt")])
-    assert False

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -91,15 +91,19 @@ def test_orderly_bound22_best():
     assert t.bound == 22
 
     failures = t.orderly_bound(15, cells, SPLIT_ORDER[(2, 2)])
-    assert set(failures) == {"teas", "teat", "taes", "taet", "rees", "reas", "raes"}
+    assert failures == snapshot(
+        [
+            (18, "seer"),
+            (18, "seat"),
+            (17, "sear"),
+            (18, "saet"),
+            (17, "saer"),
+            (20, "teat"),
+            (20, "taet"),
+        ]
+    )
 
-    # 18 teas
-    # 20 teat
-    # 18 taes
-    # 20 taet
-    # 18 rees
-    # 17 reas
-    # 17 raes
+    # TODO: confirm these via ibuckets
 
 
 def test_orderly_bound33():

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -120,10 +120,11 @@ def test_orderly_bound33():
     t = otb.BuildTree(arena)
     t.assert_invariants(otb)
     assert t.bound > 500
+    print(otb.cell_counts)
 
     # start_s = time.time()
     failures = t.orderly_bound(500, cells, SPLIT_ORDER[(3, 3)])
     # print(time.time() - start_s)
     # break_all reports 889 points for this board, but ibucket_solver reports 512
     assert failures == snapshot([(512, "stsaseblt")])
-    # assert False
+    assert False

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -40,13 +40,13 @@ def test_build_orderly_tree(TrieT, TreeBuilderT):
     )
 
 
-@pytest.mark.parametrize(
-    "make_trie, get_tree_builder",
-    [
-        (make_py_trie, OrderlyTreeBuilder),
-        (Trie.CreateFromFile, cpp_orderly_tree_builder),
-    ],
-)
+OTB_PARAMS = [
+    (make_py_trie, OrderlyTreeBuilder),
+    (Trie.CreateFromFile, cpp_orderly_tree_builder),
+]
+
+
+@pytest.mark.parametrize("make_trie, get_tree_builder", OTB_PARAMS)
 def test_lift_invariants_33(make_trie, get_tree_builder):
     trie = make_trie("testdata/boggle-words-9.txt")
     board = ". . . . lnrsy e aeiou aeiou ."
@@ -64,13 +64,7 @@ def test_lift_invariants_33(make_trie, get_tree_builder):
     )
 
 
-@pytest.mark.parametrize(
-    "make_trie, get_tree_builder",
-    [
-        (make_py_trie, OrderlyTreeBuilder),
-        (Trie.CreateFromFile, cpp_orderly_tree_builder),
-    ],
-)
+@pytest.mark.parametrize("make_trie, get_tree_builder", OTB_PARAMS)
 def test_orderly_bound22(make_trie, get_tree_builder):
     trie = make_trie("testdata/boggle-words-4.txt")
     board = "ab cd ef gh"
@@ -88,16 +82,18 @@ def test_orderly_bound22(make_trie, get_tree_builder):
     assert failures == [(8, "adeg"), (7, "adeh")]
 
 
-def test_orderly_bound22_best():
-    trie = make_py_trie("testdata/boggle-words-4.txt")
+@pytest.mark.parametrize("make_trie, get_tree_builder", OTB_PARAMS)
+def test_orderly_bound22_best(make_trie, get_tree_builder):
+    trie = make_trie("testdata/boggle-words-4.txt")
     board = "st ea ea tr"
     cells = board.split(" ")
     # num_letters = [len(cell) for cell in cells]
-    otb = OrderlyTreeBuilder(trie, dims=(2, 2))
+    otb = get_tree_builder(trie, dims=(2, 2))
     otb.ParseBoard(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
-    t.assert_invariants(otb)
+    if isinstance(t, EvalNode):
+        t.assert_invariants(otb)
     assert t.bound == 22
 
     failures = t.orderly_bound(15, cells, SPLIT_ORDER[(2, 2)])
@@ -116,19 +112,21 @@ def test_orderly_bound22_best():
     # TODO: confirm these via ibuckets
 
 
-def test_orderly_bound33():
-    trie = make_py_trie("testdata/boggle-words-9.txt")
+@pytest.mark.parametrize("make_trie, get_tree_builder", OTB_PARAMS)
+def test_orderly_bound33(make_trie, get_tree_builder):
+    trie = make_trie("testdata/boggle-words-9.txt")
     board = "lnrsy chkmpt lnrsy aeiou lnrsy aeiou bdfgjvwxz lnrsy chkmpt"
     # board = "lnrsy chkmpt lnrsy aeiou aeiou aeiou bdfgjvwxz lnrsy chkmpt"
     cells = board.split(" ")
     # num_letters = [len(cell) for cell in cells]
-    otb = OrderlyTreeBuilder(trie, dims=(3, 3))
+    otb = get_tree_builder(trie, dims=(3, 3))
     otb.ParseBoard(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
-    t.assert_invariants(otb)
+    if isinstance(t, EvalNode):
+        t.assert_invariants(otb)
+        print(otb.cell_counts)
     assert t.bound > 500
-    print(otb.cell_counts)
 
     start_s = time.time()
     failures = t.orderly_bound(500, cells, SPLIT_ORDER[(3, 3)])

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -62,11 +62,11 @@ def test_lift_invariants_33(make_trie, get_tree_builder):
     )
 
 
-def test_orderly_bound():
+def test_orderly_bound22():
     trie = make_py_trie("testdata/boggle-words-4.txt")
     board = "ab cd ef gh"
     cells = board.split(" ")
-    num_letters = [len(cell) for cell in cells]
+    # num_letters = [len(cell) for cell in cells]
     otb = OrderlyTreeBuilder(trie, dims=(2, 2))
     otb.ParseBoard(board)
     arena = otb.create_arena()
@@ -74,5 +74,21 @@ def test_orderly_bound():
     t.assert_invariants(otb)
     assert t.bound == 8
 
-    t.orderly_bound(6, num_letters, SPLIT_ORDER[(2, 2)])
-    assert False
+    failures = t.orderly_bound(6, cells, SPLIT_ORDER[(2, 2)])
+    assert failures == ["adeg", "adeh"]
+
+
+def test_orderly_bound33():
+    trie = make_py_trie("testdata/boggle-words-9.txt")
+    board = "lnrsy chkmpt lnrsy aeiou aeiou aeiou bdfgjvwxz lnrsy chkmpt"
+    cells = board.split(" ")
+    # num_letters = [len(cell) for cell in cells]
+    otb = OrderlyTreeBuilder(trie, dims=(3, 3))
+    otb.ParseBoard(board)
+    arena = otb.create_arena()
+    t = otb.BuildTree(arena)
+    t.assert_invariants(otb)
+    assert t.bound > 500
+
+    failures = t.orderly_bound(500, cells, SPLIT_ORDER[(3, 3)])
+    assert failures == ["streaedlp"]

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -136,8 +136,8 @@ def test_orderly_bound33(make_trie, get_tree_builder):
     # assert False
 
 
-def test_lift_and_bound():
-    make_trie, get_tree_builder = make_py_trie, OrderlyTreeBuilder
+@pytest.mark.parametrize("make_trie, get_tree_builder", OTB_PARAMS)
+def test_lift_and_bound(make_trie, get_tree_builder):
     trie = make_trie("testdata/boggle-words-9.txt")
     board = "lnrsy chkmpt lnrsy aeiou lnrsy aeiou bdfgjvwxz lnrsy chkmpt"
     # board = "lnrsy chkmpt lnrsy aeiou aeiou aeiou bdfgjvwxz lnrsy chkmpt"
@@ -169,10 +169,11 @@ def test_lift_and_bound():
 
     failures = []
     for tree, seq in t.max_subtrees():
-        start_s = time.time()
-        failures += tree.orderly_bound(500, cells, order, seq)
-        print(time.time() - start_s, seq, tree.bound, failures)
+        # start_s = time.time()
+        this_failures = tree.orderly_bound(500, cells, order, seq)
+        # print(time.time() - start_s, seq, tree.bound, this_failures)
+        failures += this_failures
 
-    # break_all reports 889 points for this board, but ibucket_solver reports 512
+    # (same as test_orderly_bound33)
     assert failures == snapshot([(512, "stsaseblt")])
     # assert False

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -5,6 +5,7 @@ from inline_snapshot import external, outsource, snapshot
 from boggle.dimensional_bogglers import cpp_orderly_tree_builder
 from boggle.eval_tree import EvalNode, eval_node_to_string
 from boggle.orderly_tree_builder import OrderlyTreeBuilder
+from boggle.split_order import SPLIT_ORDER
 from boggle.trie import PyTrie, make_py_trie
 
 
@@ -65,9 +66,13 @@ def test_orderly_bound():
     trie = make_py_trie("testdata/boggle-words-4.txt")
     board = "ab cd ef gh"
     cells = board.split(" ")
+    num_letters = [len(cell) for cell in cells]
     otb = OrderlyTreeBuilder(trie, dims=(2, 2))
     otb.ParseBoard(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
     t.assert_invariants(otb)
     assert t.bound == 8
+
+    t.orderly_bound(6, num_letters, SPLIT_ORDER[(2, 2)])
+    assert False

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from cpp_boggle import Trie
 from inline_snapshot import external, outsource, snapshot
@@ -108,7 +110,8 @@ def test_orderly_bound22_best():
 
 def test_orderly_bound33():
     trie = make_py_trie("testdata/boggle-words-9.txt")
-    board = "lnrsy chkmpt lnrsy aeiou aeiou aeiou bdfgjvwxz lnrsy chkmpt"
+    board = "lnrsy chkmpt lnrsy aeiou lnrsy aeiou bdfgjvwxz lnrsy chkmpt"
+    # board = "lnrsy chkmpt lnrsy aeiou aeiou aeiou bdfgjvwxz lnrsy chkmpt"
     cells = board.split(" ")
     # num_letters = [len(cell) for cell in cells]
     otb = OrderlyTreeBuilder(trie, dims=(3, 3))
@@ -118,5 +121,9 @@ def test_orderly_bound33():
     t.assert_invariants(otb)
     assert t.bound > 500
 
+    # start_s = time.time()
     failures = t.orderly_bound(500, cells, SPLIT_ORDER[(3, 3)])
-    assert failures == ["streaedlp"]
+    # print(time.time() - start_s)
+    # break_all reports 889 points for this board, but ibucket_solver reports 512
+    assert failures == snapshot([(512, "stsaseblt")])
+    # assert False

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -77,7 +77,7 @@ def test_orderly_bound22():
     assert t.bound == 8
 
     failures = t.orderly_bound(6, cells, SPLIT_ORDER[(2, 2)])
-    assert failures == ["adeg", "adeh"]
+    assert failures == [(8, "adeg"), (7, "adeh")]
 
 
 def test_orderly_bound22_best():

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -78,7 +78,7 @@ def test_orderly_bound22(make_trie, get_tree_builder):
         t.assert_invariants(otb)
     assert t.bound == 8
 
-    failures = t.orderly_bound(6, cells, SPLIT_ORDER[(2, 2)])
+    failures = t.orderly_bound(6, cells, SPLIT_ORDER[(2, 2)], [])
     assert failures == [(8, "adeg"), (7, "adeh")]
 
 
@@ -96,7 +96,7 @@ def test_orderly_bound22_best(make_trie, get_tree_builder):
         t.assert_invariants(otb)
     assert t.bound == 22
 
-    failures = t.orderly_bound(15, cells, SPLIT_ORDER[(2, 2)])
+    failures = t.orderly_bound(15, cells, SPLIT_ORDER[(2, 2)], [])
     assert failures == snapshot(
         [
             (18, "seer"),
@@ -129,7 +129,7 @@ def test_orderly_bound33(make_trie, get_tree_builder):
     assert t.bound > 500
 
     start_s = time.time()
-    failures = t.orderly_bound(500, cells, SPLIT_ORDER[(3, 3)])
+    failures = t.orderly_bound(500, cells, SPLIT_ORDER[(3, 3)], [])
     print(time.time() - start_s)
     # break_all reports 889 points for this board, but ibucket_solver reports 512
     assert failures == snapshot([(512, "stsaseblt")])

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -64,16 +64,24 @@ def test_lift_invariants_33(make_trie, get_tree_builder):
     )
 
 
-def test_orderly_bound22():
-    trie = make_py_trie("testdata/boggle-words-4.txt")
+@pytest.mark.parametrize(
+    "make_trie, get_tree_builder",
+    [
+        (make_py_trie, OrderlyTreeBuilder),
+        (Trie.CreateFromFile, cpp_orderly_tree_builder),
+    ],
+)
+def test_orderly_bound22(make_trie, get_tree_builder):
+    trie = make_trie("testdata/boggle-words-4.txt")
     board = "ab cd ef gh"
     cells = board.split(" ")
     # num_letters = [len(cell) for cell in cells]
-    otb = OrderlyTreeBuilder(trie, dims=(2, 2))
+    otb = get_tree_builder(trie, dims=(2, 2))
     otb.ParseBoard(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
-    t.assert_invariants(otb)
+    if isinstance(t, EvalNode):
+        t.assert_invariants(otb)
     assert t.bound == 8
 
     failures = t.orderly_bound(6, cells, SPLIT_ORDER[(2, 2)])

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -122,8 +122,9 @@ def test_orderly_bound33():
     assert t.bound > 500
     print(otb.cell_counts)
 
-    # start_s = time.time()
+    start_s = time.time()
     failures = t.orderly_bound(500, cells, SPLIT_ORDER[(3, 3)])
-    # print(time.time() - start_s)
+    print(time.time() - start_s)
     # break_all reports 889 points for this board, but ibucket_solver reports 512
     assert failures == snapshot([(512, "stsaseblt")])
+    assert False

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -1,13 +1,11 @@
 import pytest
 from cpp_boggle import Trie
-from inline_snapshot import outsource, snapshot
+from inline_snapshot import external, outsource, snapshot
 
 from boggle.dimensional_bogglers import cpp_orderly_tree_builder
 from boggle.eval_tree import EvalNode, eval_node_to_string
 from boggle.orderly_tree_builder import OrderlyTreeBuilder
 from boggle.trie import PyTrie, make_py_trie
-
-from inline_snapshot import external
 
 
 @pytest.mark.parametrize(
@@ -61,3 +59,15 @@ def test_lift_invariants_33(make_trie, get_tree_builder):
     assert outsource(eval_node_to_string(t, cells)) == snapshot(
         external("31d49f6a9eab*.txt")
     )
+
+
+def test_orderly_bound():
+    trie = make_py_trie("testdata/boggle-words-4.txt")
+    board = "ab cd ef gh"
+    cells = board.split(" ")
+    otb = OrderlyTreeBuilder(trie, dims=(2, 2))
+    otb.ParseBoard(board)
+    arena = otb.create_arena()
+    t = otb.BuildTree(arena)
+    t.assert_invariants(otb)
+    assert t.bound == 8

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -78,6 +78,22 @@ def test_orderly_bound22():
     assert failures == ["adeg", "adeh"]
 
 
+def test_orderly_bound22_best():
+    trie = make_py_trie("testdata/boggle-words-4.txt")
+    board = "st ea ea tr"
+    cells = board.split(" ")
+    # num_letters = [len(cell) for cell in cells]
+    otb = OrderlyTreeBuilder(trie, dims=(2, 2))
+    otb.ParseBoard(board)
+    arena = otb.create_arena()
+    t = otb.BuildTree(arena)
+    t.assert_invariants(otb)
+    assert t.bound == 8
+
+    failures = t.orderly_bound(6, cells, SPLIT_ORDER[(2, 2)])
+    assert failures == ["adeg", "adeh"]
+
+
 def test_orderly_bound33():
     trie = make_py_trie("testdata/boggle-words-9.txt")
     board = "lnrsy chkmpt lnrsy aeiou aeiou aeiou bdfgjvwxz lnrsy chkmpt"

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -127,4 +127,4 @@ def test_orderly_bound33():
     print(time.time() - start_s)
     # break_all reports 889 points for this board, but ibucket_solver reports 512
     assert failures == snapshot([(512, "stsaseblt")])
-    assert False
+    # assert False

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -88,10 +88,18 @@ def test_orderly_bound22_best():
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
     t.assert_invariants(otb)
-    assert t.bound == 8
+    assert t.bound == 22
 
-    failures = t.orderly_bound(6, cells, SPLIT_ORDER[(2, 2)])
-    assert failures == ["adeg", "adeh"]
+    failures = t.orderly_bound(15, cells, SPLIT_ORDER[(2, 2)])
+    assert set(failures) == {"teas", "teat", "taes", "taet", "rees", "reas", "raes"}
+
+    # 18 teas
+    # 20 teat
+    # 18 taes
+    # 20 taet
+    # 18 rees
+    # 17 reas
+    # 17 raes
 
 
 def test_orderly_bound33():

--- a/boggle/split_order.py
+++ b/boggle/split_order.py
@@ -1,5 +1,7 @@
 """Order in which to split cells. Middle then edges then corners."""
 
+from typing import Sequence
+
 SPLIT_ORDER_33 = (4, 5, 3, 1, 7, 0, 2, 6, 8)
 
 
@@ -50,7 +52,7 @@ SPLIT_ORDER_44 = tuple(
 assert len(SPLIT_ORDER_44) == 16
 assert len(set(SPLIT_ORDER_44)) == 16
 
-SPLIT_ORDER = {
+SPLIT_ORDER: dict[tuple[int, int], Sequence[int]] = {
     (2, 2): (0, 1, 2, 3),
     (2, 3): (0, 1, 2, 3, 4, 5),
     (3, 3): SPLIT_ORDER_33,

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -149,6 +149,7 @@ PYBIND11_MODULE(cpp_boggle, m)
         .def("set_choice_point_mask", &EvalNode::SetChoicePointMask)
         .def("reset_choice_point_mask", &EvalNode::ResetChoicePointMask)
         .def("filter_below_threshold", &EvalNode::FilterBelowThreshold)
+        .def("orderly_bound", &EvalNode::OrderlyBound)
         .def("bound_remaining_boards", &EvalNode::BoundRemainingBoards);
 
     m.def("create_eval_node_arena", &create_eval_node_arena);

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -952,15 +952,15 @@ void merge_choice_collisions_in_place(
   }
 }
 
-void EvalNode::OrderlyBound(
+vector<pair<int, string>> EvalNode::OrderlyBound(
   int cutoff,
   const vector<string>& cells,
-  const vector<int>& split_order,
-  vector<string>& failures
+  const vector<int>& split_order
 ) const {
   vector<vector<const EvalNode*>> stacks(cells.size());
   vector<pair<int, int>> choices;
   vector<int> stack_sums(cells.size(), 0);
+  vector<pair<int, string>> failures;
 
   auto advance = [&](const EvalNode* node, vector<int>& sums) {
     assert(node->letter_ != CHOICE_NODE);
@@ -977,7 +977,7 @@ void EvalNode::OrderlyBound(
     for (const auto& choice : choices) {
       board[choice.first] = cells[choice.first][choice.second];
     }
-    failures.push_back(board);
+    failures.push_back({bound, board});
   };
 
   function<bool(int, int, vector<int>&)> rec = [&](int base_points, int num_splits, vector<int>& stack_sums) {
@@ -1030,4 +1030,5 @@ void EvalNode::OrderlyBound(
   vector<int> sums(cells.size(), 0);
   assert(advance(this, sums) == 0);
   rec(0, 0, sums);
+  return failures;
 }

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -990,7 +990,7 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
     }
     if (num_splits == split_order.size()) {
       record_failure(bound);
-      return false;
+      return false;  // TODO: return value is not meaningful.
     }
 
     int next_to_split = split_order[num_splits];
@@ -1004,6 +1004,7 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
       if (letter > 0) {
         stack_sums = base_sums;
         for (int i = 0; i < stacks.size(); ++i) {
+          // TODO: this might de-allocate, which we don't want.
           stacks[i].resize(stack_top[i]);
         }
       }

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -980,17 +980,17 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
     failures.push_back({bound, board});
   };
 
-  function<bool(int, int, vector<int>&)> rec = [&](int base_points, int num_splits, vector<int>& stack_sums) {
+  function<void(int, int, vector<int>&)> rec = [&](int base_points, int num_splits, vector<int>& stack_sums) {
     int bound = base_points;
     for (int i = num_splits; i < split_order.size(); ++i) {
       bound += stack_sums[split_order[i]];
     }
     if (bound <= cutoff) {
-      return true;  // done!
+      return;  // done!
     }
     if (num_splits == split_order.size()) {
       record_failure(bound);
-      return false;  // TODO: return value is not meaningful.
+      return;
     }
 
     int next_to_split = split_order[num_splits];
@@ -1004,7 +1004,8 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
       if (letter > 0) {
         stack_sums = base_sums;
         for (int i = 0; i < stacks.size(); ++i) {
-            stacks[i].erase(stacks[i].begin() + stack_top[i], stacks[i].end());
+          // TODO: don't do this, just leave garbage on the end.
+          stacks[i].resize(stack_top[i]);
         }
       }
       choices.emplace_back(next_to_split, letter);
@@ -1024,7 +1025,6 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
       rec(points, num_splits + 1, stack_sums);
       choices.pop_back();
     }
-    return false;
   };
 
   vector<int> sums(cells.size(), 0);

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -955,7 +955,8 @@ void merge_choice_collisions_in_place(
 vector<pair<int, string>> EvalNode::OrderlyBound(
   int cutoff,
   const vector<string>& cells,
-  const vector<int>& split_order
+  const vector<int>& split_order,
+  const vector<pair<int, int>>* preset_cells
 ) const {
   vector<vector<const EvalNode*>> stacks(cells.size());
   vector<pair<int, int>> choices;
@@ -974,6 +975,11 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
 
   auto record_failure = [&](int bound) {
     string board(cells.size(), '.');
+    if (preset_cells) {
+      for (const auto& choice : *preset_cells) {
+        board[choice.first] = cells[choice.first][choice.second];
+      }
+    }
     for (const auto& choice : choices) {
       board[choice.first] = cells[choice.first][choice.second];
     }

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -1034,7 +1034,7 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
   };
 
   vector<int> sums(cells.size(), 0);
-  assert(advance(this, sums) == 0);
-  rec(0, 0, sums);
+  auto base_points = advance(this, sums);
+  rec(base_points, 0, sums);
   return failures;
 }

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -1004,8 +1004,7 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
       if (letter > 0) {
         stack_sums = base_sums;
         for (int i = 0; i < stacks.size(); ++i) {
-          // TODO: this might de-allocate, which we don't want.
-          stacks[i].resize(stack_top[i]);
+            stacks[i].erase(stacks[i].begin() + stack_top[i], stacks[i].end());
         }
       }
       choices.emplace_back(next_to_split, letter);

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -134,7 +134,8 @@ class EvalNode {
   vector<pair<int, string>> OrderlyBound(
     int cutoff,
     const vector<string>& cells,
-    const vector<int>& split_order
+    const vector<int>& split_order,
+    const vector<pair<int, int>>* preset_cells = NULL
   ) const;
 
  private:

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -131,6 +131,13 @@ class EvalNode {
     vector<int> split_order
   );
 
+  void OrderlyBound(
+    int cutoff,
+    const vector<string>& cells,
+    const vector<int>& split_order,
+    vector<string>& failures
+  ) const;
+
  private:
   unsigned int ScoreWithForcesMask(const vector<int>& forces, uint16_t choice_mask) const;
   void MaxSubtreesHelp(vector<pair<const EvalNode*, vector<pair<int, int>>>>& out, vector<pair<int, int>> path) const;

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -131,11 +131,10 @@ class EvalNode {
     vector<int> split_order
   );
 
-  void OrderlyBound(
+  vector<pair<int, string>> OrderlyBound(
     int cutoff,
     const vector<string>& cells,
-    const vector<int>& split_order,
-    vector<string>& failures
+    const vector<int>& split_order
   ) const;
 
  private:

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -135,7 +135,7 @@ class EvalNode {
     int cutoff,
     const vector<string>& cells,
     const vector<int>& split_order,
-    const vector<pair<int, int>>* preset_cells = NULL
+    const vector<pair<int, int>>* preset_cells
   ) const;
 
  private:


### PR DESCRIPTION
I got this idea from the visualizations in my [recent blog post][1]:

![image](https://github.com/user-attachments/assets/83174406-bf4d-44f8-b293-1a8944dfa773)

- Start with the leftmost blue and green choice cells.
- Sum their bounds. If it's less than the cutoff, you're done.
- If not, try each possible blue choice and continue down that path to all the next choices.

You maintain a stack of nodes for choices on each cell and steadily remove early choices and replace them with more later choices. You're able to prune as you go, just like with BoundRemainingBoards. It's kind of like a BFS that takes advantage of the "orderly" structure of the tree. It should only visit each node once, producing the max/no-mark bound for each board if you get all the way to a leaf. If you have an orderly tree, it's a drop-in replacement for BoundRemainingBoards that's ~10x faster. If not, it doesn't work (it would require backtracking).

This is a huge speedup for BoundRemainingBoards. I'd hoped that it would be a big enough speedup that I could ditch lifting entirely. That doesn't quite seem to be the case. Going straight from `build_tree` to `orderly_bound` gets me the fastest time I've seen yet on the 50 board test set, 21s vs 23s before. And it uses less RAM. But it's slower than lifting for the hardest 3x4 board classes by around 30%.

207836 (hard):

- old switch=0: 12.94 = 1.16 + 11.46 (706MB)
- old switch=2: 5.29 = 0.96 + 0.36 + 3.6 (806MB)
- old switch=4: 3.30 = 0.95 + 0.67 + 0.38 + 0.68 + 0.30 (1.41GB)
- orderly bound: 3.86 = 1.01 + 2.64 (707MB)
- orderly switch=2: 2.62 = 1 + 0.39 + 1.22

234556 (best):

- brb s=0: 310s
- brb s=4: 23.66s = 2.4s + 0.98s + 0.90s + 1.99s + 15.4s + 0.4s (2.8GB)
- new: 37.61s = 2.2s + 34.6s + 0.4s (1.2GB)
- new s=2: 20.72s = 2.2 + 0.9 + 17.2 + 0.4s (1.48GB)
- new s=3: 14.45s = 2.2 + 0.9 + 0.9 + 10 + 0.4s (1.76GB)
- new s=4: 11.34s = 2.1 + 0.9 + 0.9 + 2 + 5 + 0.4s (2.8GB)

524960 (hardest):

- brb s=4: 46.66s = 2.1s + 0.6s + 0.6s + 1.4s + 38s + 3.4s (2.17G)
- brb s=5: 27.12s = 1.9s + 0.6s + 0.6s + 1.5s + 4s + 13.5s + 3.4s (3.81G)
- new: 53.8s = 1.9s + 48.5s + 3.4s (1.13GB)
- new s=2: 36.66s = 1.9 + 0.74 + 30.62 + 3.4s (1.29GB)
- new s=3: 25.47s = 1.8 + 0.6 + 0.6 + 19 + 3.4s (1.61GB)
- new s=4: 18.53s = 2 + 0.6 + 0.6 + 1.3 + 10.6 + 3.4 (2.18G)
- new s=5: 17.8 = 1.8 + 0.6 + 0.6 + 1.2 + 4.3 + 5.8 + 3.5 (3.84G)

So the fastest approach winds up being lifting + orderly bounds, at least for hard boards. A lifted orderly tree is still orderly. It just means that I wouldn't be able to refactor EvalNodes without re-implementing lifting. This shifts the curve for switchover levels in a good way: switchover=5 is only marginally faster for 524960 whereas previously it was a clear win. Or alternatively you can lower the switchover level to get a similar runtime but use a lot less memory.

To-do before merging:

- [x] Get it working with lifted trees or pull it out of breaker.
- [x] Figure out why ordery_bound crashes after 4 lifts

[1]: https://www.danvk.org/2025/02/21/orderly-boggle.html