### PR TITLE
EvalTree easy size wins

### DIFF
--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -17,11 +17,6 @@ class EvalNode;
 template<typename T>
 class Arena {
  public:
-  Arena() {
-    cout << "sizeof(T) = " << sizeof(T) << endl;
-    // Init: sizeof(T) = 80
-    // Drop virtual destructor: 72
-  }
   ~Arena() {
     FreeTheChildren();
   }
@@ -110,12 +105,12 @@ class EvalNode {
   // points contributed by _this_ node.
   uint16_t points_;
 
+  // cached computation across all children
+  uint32_t bound_;
+
   // These might be the various options on a cell or the various directions.
   // TODO: the "const" here is increasingly a joke.
   vector<const EvalNode*> children_;
-
-  // cached computation across all children
-  uint32_t bound_;
 
   // Note: using uint16_t here precludes 5x5 Boggle trees
   uint16_t choice_mask_;

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -17,6 +17,11 @@ class EvalNode;
 template<typename T>
 class Arena {
  public:
+  Arena() {
+    cout << "sizeof(T) = " << sizeof(T) << endl;
+    // Init: sizeof(T) = 80
+    // Drop virtual destructor: 72
+  }
   ~Arena() {
     FreeTheChildren();
   }
@@ -65,7 +70,7 @@ unique_ptr<VectorArena> create_vector_arena();
 class EvalNode {
  public:
   EvalNode() : points_(0), choice_mask_(0), cache_key_(0), hash_(0) {}
-  virtual ~EvalNode() {}
+  ~EvalNode() {}
 
   void AddWord(vector<pair<int, int>> choices, int points, EvalNodeArena& arena);
   void AddWordWork(int num_choices, pair<int, int>* choices, const int* num_letters, int points, EvalNodeArena& arena);
@@ -102,15 +107,15 @@ class EvalNode {
   static const int8_t ROOT_NODE = -2;
   static const int8_t CHOICE_NODE = -1;
 
+  // points contributed by _this_ node.
+  uint16_t points_;
+
   // These might be the various options on a cell or the various directions.
   // TODO: the "const" here is increasingly a joke.
   vector<const EvalNode*> children_;
 
   // cached computation across all children
   uint32_t bound_;
-
-  // points contributed by _this_ node.
-  uint32_t points_;
 
   // Note: using uint16_t here precludes 5x5 Boggle trees
   uint16_t choice_mask_;

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -64,6 +64,22 @@ const EvalNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool d
   auto root = root_;
   root_ = NULL;
   arena.AddNode(root);
+
+  /*
+  // This can be used to investigate the layout of EvalNode.
+  cout << "sizeof(EvalNode) = " << sizeof(EvalNode) << endl;
+  cout << "root: " << (uintptr_t)root << endl;
+  auto r = (uintptr_t)root;
+  cout << "root->letter_: " << (uintptr_t)(&root->letter_) - r << endl;
+  cout << "root->cell_: " << (uintptr_t)&root->cell_ - r << endl;
+  cout << "root->points_: " << (uintptr_t)&root->points_ - r << endl;
+  cout << "root->bound_: " << (uintptr_t)&root->bound_ - r << endl;
+  cout << "root->children_: " << (uintptr_t)&root->children_ - r << endl;
+  cout << "root->cache_key_: " << (uintptr_t)&root->cache_key_ - r << endl;
+  cout << "root->cache_value_: " << (uintptr_t)&root->cache_value_ - r << endl;
+  cout << "root->hash_: " << (uintptr_t)&root->hash_ - r << endl;
+  */
+
   return root;
 }
 


### PR DESCRIPTION
#12 

This shrinks `EvalNode` from 80 bytes to 64 bytes. The only remotely controversial thing here is making `points_` a `uint16_t`, which introduces the possibility of overflow. I haven't seen orderly _bounds_ anywhere near this high, though, and `points` should always be significantly less than `bound_`.

This is a 20% reduction in `sizeof(EvalNode)`, which corresponds to something like a 14% reduction in memory usage.