### PR TITLE
Advance iterators in lockstep in OrderlyBound

### DIFF
--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -101,12 +101,12 @@ def break_worker(task: str | int):
     # times[round(10 * details.elapsed_s) / 10] += 1
     # all_details.append((task, details))
     with open(f"tasks-{me}.ndjson", "a") as out:
-        summary = details.asdict()
+        # It's convenient to have id first when viewing.
+        summary = {"id": task, **details.asdict()}
         if args.omit_times:
             del summary["elapsed_s"]
             del summary["free_time_s"]
             del summary["secs_by_level"]
-        summary["id"] = task
         out.write(json.dumps(summary))
         out.write("\n")
         if args.log_per_board_stats:

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -960,8 +960,8 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
     its.reserve(next_stack.size());
     end_its.reserve(next_stack.size());
     for (auto& n : next_stack) {
-      assert(n->letter_ == CHOICE_NODE);
-      assert(n->cell_ == next_to_split);
+      // assert(n->letter_ == CHOICE_NODE);
+      // assert(n->cell_ == next_to_split);
       its.push_back(n->children_.begin());
       end_its.push_back(n->children_.end());
     }

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -958,7 +958,12 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
     vector<int> base_sums = stack_sums;
 
     auto& next_stack = stacks[next_to_split];
-    vector<pair<vector<const EvalNode *>::const_iterator, vector<const EvalNode *>::const_iterator>> its;
+    vector<
+      pair<
+        vector<const EvalNode *>::const_iterator,
+        vector<const EvalNode *>::const_iterator
+      >
+    > its;
     its.reserve(next_stack.size());
     for (auto& n : next_stack) {
       // assert(n->letter_ == CHOICE_NODE);

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -960,6 +960,8 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
     its.reserve(next_stack.size());
     end_its.reserve(next_stack.size());
     for (auto& n : next_stack) {
+      assert(n->letter_ == CHOICE_NODE);
+      assert(n->cell_ == next_to_split);
       its.push_back(n->children_.begin());
       end_its.push_back(n->children_.end());
     }
@@ -979,7 +981,7 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
       int points = base_points;
       int n = its.size();
       for (int i = 0; i < n; i++) {
-        auto it = its[i];
+        auto& it = its[i];
         auto end = end_its[i];
         if (it != end && (*it)->letter_ == letter) {
           points += advance(*it, stack_sums);

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -958,16 +958,12 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
     vector<int> base_sums = stack_sums;
 
     auto& next_stack = stacks[next_to_split];
-    // TODO: maybe make these pairs of iterators?
-    vector<vector<const EvalNode *>::const_iterator> its;
-    vector<vector<const EvalNode *>::const_iterator> end_its;
+    vector<pair<vector<const EvalNode *>::const_iterator, vector<const EvalNode *>::const_iterator>> its;
     its.reserve(next_stack.size());
-    end_its.reserve(next_stack.size());
     for (auto& n : next_stack) {
       // assert(n->letter_ == CHOICE_NODE);
       // assert(n->cell_ == next_to_split);
-      its.push_back(n->children_.begin());
-      end_its.push_back(n->children_.end());
+      its.push_back({n->children_.begin(), n->children_.end()});
     }
 
     int num_letters = cells[next_to_split].size();
@@ -983,10 +979,7 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
       }
       choices.emplace_back(next_to_split, letter);
       int points = base_points;
-      int n = its.size();
-      for (int i = 0; i < n; i++) {
-        auto& it = its[i];
-        auto end = end_its[i];
+      for (auto& [it, end] : its) {
         if (it != end && (*it)->letter_ == letter) {
           points += advance(*it, stack_sums, stacks);
           ++it;

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -964,7 +964,8 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
       end_its.push_back(n->children_.end());
     }
 
-    for (int letter = 0; letter < cells[next_to_split].size(); ++letter) {
+    int num_letters = cells[next_to_split].size();
+    for (int letter = 0; letter < num_letters; ++letter) {
       if (letter > 0) {
         // TODO: it should be possible to avoid this copy with another stack.
         stack_sums = base_sums;
@@ -982,8 +983,8 @@ vector<pair<int, string>> EvalNode::OrderlyBound(
         auto end = end_its[i];
         if (it != end && (*it)->letter_ == letter) {
           points += advance(*it, stack_sums);
+          ++it;
         }
-        ++it;
       }
       rec(points, num_splits + 1, stack_sums);
       choices.pop_back();

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -24,6 +24,7 @@ Found unbreakable board for 2520743: pansliteserd
 Found unbreakable board for 2520743: perslitesand
 2520743: chkmpt aeiou lnrsy lnrsy lnrsy aeiou chkmpt aeiou lnrsy aeiou lnrsy bdfgjvwxz
 {
+  "id": 2520743,
   "num_reps": 632812500,
   "failures": [
     "cerslatesind",
@@ -53,8 +54,7 @@ Found unbreakable board for 2520743: perslitesand
   "init_nodes": 1960065,
   "total_nodes": 2362581,
   "freed_nodes": 0,
-  "num_filtered": {},
-  "id": 2520743
+  "num_filtered": {}
 }
 Found 12 breaking failure(s):
 cerslatesind


### PR DESCRIPTION
This is a 20-25% optimization for hard 4x4 boards. No needless O(N) searches in your inner loop!

It may be slightly worse for easier boards, but those aren't the ones I'm interested in now.