### PR TITLE
Force to variable depths based on score

### DIFF
--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -131,20 +131,13 @@ def get_breaker(args) -> BreakingBundle:
     etb = builder(t, dims)
 
     if args.breaker == "hybrid":
-        switchover_level = 2
-        if args.switchover_level is not None:
-            switchover_level = args.switchover_level
-        elif args.switchover_sizes:
-            switchover_level = [
-                tuple(int(x) for x in pair.split(":"))
-                for pair in args.switchover_sizes.split(",")
-            ]
+        switchover_score = args.switchover_score or 2.5 * best_score
         breaker = HybridTreeBreaker(
             etb,
             boggler,
             dims,
             best_score,
-            switchover_level=switchover_level,
+            switchover_score=switchover_score,
             log_breaker_progress=args.log_breaker_progress,
             letter_grouping=args.letter_grouping,
         )
@@ -192,20 +185,13 @@ def main():
         default=4,
         help="Number of partitions to use when breaking a bucket. Only relevant with --breaker=ibuckets.",
     )
-    switchovers = parser.add_mutually_exclusive_group()
-    switchovers.add_argument(
-        "--switchover_level",
+    parser.add_argument(
+        "--switchover_score",
         type=int,
         default=None,
-        help="Depth at which to switch from lifting choices to exhaustively trying them. "
-        "Default is 2, unless you set --switchover_sizes. Only relevant with --breaker=hybrid.",
-    )
-    switchovers.add_argument(
-        "--switchover_sizes",
-        type=str,
-        default=None,
-        help='Initial size -> switchover map. Format is "switch:size,switch:size". For example, '
-        '"2:100,4:1000" would use switchover=0 for 0-99, 2 for 100-999, and 4 for 1000+.',
+        help="When to switch from splitting the tree by forcing cells to evaluating the "
+        "remaining tree with a DFS. Higher values will use less RAM but potentially run "
+        "more slowly. The default is 2.5 * best_score.",
     )
     parser.add_argument(
         "--breaker",

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -160,7 +160,7 @@ class HybridTreeBreaker:
     ) -> None:
         if tree.bound <= self.best_score:
             self.details_.elim_level[level] += 1
-        elif tree.bound <= self.switchover_score:
+        elif tree.bound <= self.switchover_score or level > 12:
             self.switch_to_score(tree, level, choices)
         else:
             self.force_and_filter(tree, level, choices)
@@ -226,12 +226,12 @@ class HybridTreeBreaker:
         if not boards_to_test:
             if self.log_breaker_progress:
                 print(
-                    f"{self.details_.n_bound} {choices} -> {tree.bound=} {bound_elapsed_s} s"
+                    f"{self.details_.n_bound} {choices} -> {tree.bound=} {bound_elapsed_s:.03} s"
                 )
             return
 
-        if self.log_breaker_progress:
-            print(f"Found {len(boards_to_test)} to test.")
+        # if self.log_breaker_progress:
+        #     print(f"Found {len(boards_to_test)} to test.")
 
         self.details_.boards_to_test += len(boards_to_test)
         start_s = time.time()
@@ -260,5 +260,5 @@ class HybridTreeBreaker:
 
         if self.log_breaker_progress:
             print(
-                f"{self.details_.n_bound} {choices} -> {tree.bound=} {bound_elapsed_s}s / test {n_expanded} in {elapsed_s}s"
+                f"{self.details_.n_bound} {choices} -> {tree.bound=} {bound_elapsed_s:.03}s / test {n_expanded} in {elapsed_s:.03}s"
             )

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -138,6 +138,8 @@ class HybridTreeBreaker:
                 if num_nodes >= size:
                     self.switchover_level = level
 
+        self.switchover_score = 8_000
+
         self.details_.secs_by_level[0] += time.time() - start_time_s
         self.details_.bounds[0] = tree.bound
         self.details_.sum_union = self.etb.SumUnion()
@@ -158,7 +160,7 @@ class HybridTreeBreaker:
     ) -> None:
         if tree.bound <= self.best_score:
             self.details_.elim_level[level] += 1
-        elif level >= self.switchover_level:
+        elif tree.bound <= self.switchover_score:
             self.switch_to_score(tree, level, choices)
         else:
             self.force_and_filter(tree, level, choices)

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -146,7 +146,7 @@ class HybridTreeBreaker:
         self.details_.init_nodes = arena.num_nodes()
         self.details_.nodes[0] = self.details_.init_nodes
 
-        self.attack_tree(tree, 1, [], arena)
+        self.attack_tree(tree, 1, [])
 
         self.details_.elapsed_s = time.time() - start_time_s
         self.details_.total_nodes = arena.num_nodes()
@@ -157,21 +157,19 @@ class HybridTreeBreaker:
         tree: EvalNode,
         level: int,
         choices: list[tuple[int, int]],
-        arena,
     ) -> None:
         if tree.bound <= self.best_score:
             self.details_.elim_level[level] += 1
         elif level >= self.switchover_level:
-            self.switch_to_score(tree, level, choices, arena)
+            self.switch_to_score(tree, level, choices)
         else:
-            self.force_and_filter(tree, level, choices, arena)
+            self.force_and_filter(tree, level, choices)
 
     def force_and_filter(
         self,
         tree: EvalNode,
         level: int,
         choices: list[tuple[int, int]],
-        arena,
     ) -> None:
         # choices list parallels split_order
         assert len(choices) < len(self.cells)
@@ -181,6 +179,7 @@ class HybridTreeBreaker:
 
         start_s = time.time()
         self.mark += 1
+        arena = self.etb.create_arena()
         trees = tree.orderly_force_cell(
             cell,
             num_lets,
@@ -201,11 +200,11 @@ class HybridTreeBreaker:
             if not tree:
                 continue  # TODO: how does this happen?
             choices[-1] = (cell, letter)
-            self.attack_tree(tree, level + 1, choices, arena)
+            self.attack_tree(tree, level + 1, choices)
         choices.pop()
 
     def switch_to_score(
-        self, tree: EvalNode, level: int, choices: list[tuple[int, int]], arena
+        self, tree: EvalNode, level: int, choices: list[tuple[int, int]]
     ) -> None:
         start_s = time.time()
         remaining_cells = self.split_order[len(choices) :]

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -128,9 +128,7 @@ class HybridTreeBreaker:
         if self.log_breaker_progress:
             # TODO: this crashes in C++, which no longer has an EvalNode::unique_node_count method.
             self.mark += 1
-            print(
-                f"root {tree.bound=}, {num_nodes} nodes, {tree.unique_node_count(self.mark)} unique nodes"
-            )
+            print(f"root {tree.bound=}, {num_nodes} nodes")
 
         if isinstance(self.switchover_level_input, int):
             self.switchover_level = self.switchover_level_input
@@ -220,10 +218,14 @@ class HybridTreeBreaker:
         #     self.details_.bound_level[i + len(choices)] += bv
         # print(time.time() - start_s, seq, tree.bound, this_failures)
         boards_to_test = [board for _score, board in score_boards]
-        elapsed_s = time.time() - start_s
-        self.details_.secs_by_level[level] += elapsed_s
+        bound_elapsed_s = time.time() - start_s
+        self.details_.secs_by_level[level] += bound_elapsed_s
 
         if not boards_to_test:
+            if self.log_breaker_progress:
+                print(
+                    f"{self.details_.n_bound} {choices} -> {tree.bound=} {bound_elapsed_s} s"
+                )
             return
 
         if self.log_breaker_progress:
@@ -253,3 +255,8 @@ class HybridTreeBreaker:
         self.details_.expanded_to_test += n_expanded
         if self.log_breaker_progress and self.rev_letter_grouping:
             print(f"Evaluated {n_expanded} boards.")
+
+        if self.log_breaker_progress:
+            print(
+                f"{self.details_.n_bound} {choices} -> {tree.bound=} {bound_elapsed_s}s / test {n_expanded} in {elapsed_s}s"
+            )

--- a/boggle/breaker_test.py
+++ b/boggle/breaker_test.py
@@ -36,7 +36,8 @@ def test_breaker(is_python):
         boggler,
         (2, 2),
         15,
-        switchover_level=2,
+        switchover_score=20,
+        max_depth=3,
         log_breaker_progress=False,
     )
 
@@ -61,15 +62,16 @@ def test_breaker(is_python):
             "failures": ["alte", "aste", "elta", "esta"],
             "elim_level": {2: 2},
             "secs_by_level": {},
-            "sum_union": 0,
             "bounds": {0: 21},
             "nodes": {0: 1186},
+            "depth": {2: 3},
             "boards_to_test": 7,
             "expanded_to_test": 7,
             "init_nodes": 1186,
-            "total_nodes": 1864,
+            "total_nodes": 1186,
             "freed_nodes": 0,
             "free_time_s": 0.0,
             "n_bound": 3,
+            "n_force": 1,
         }
     )

--- a/boggle/eval_tree.py
+++ b/boggle/eval_tree.py
@@ -220,29 +220,6 @@ class EvalNode:
                     out[i] = point_node
         return out
 
-    def filter_below_threshold(self, min_score: int) -> int:
-        """Remove choice subtrees with bounds equal to or below min_score.
-
-        This operates in-place. It only operates on subtrees that are connected
-        to the root exclusively through choice nodes. This won't reduce any bounds,
-        but it will reduce the number of nodes.
-        """
-        # TODO: this would be more efficient to do in force_cell.
-        # this could use the caching system, but it's unlikely that the max trees are cached.
-        if self.letter != CHOICE_NODE:
-            return 0
-        assert self.bound > min_score
-        n_filtered = 0
-        for i, child in enumerate(self.children):
-            if not child:
-                continue
-            if child.bound <= min_score:
-                self.children[i] = None
-                n_filtered += 1
-            else:
-                n_filtered += child.filter_below_threshold(min_score)
-        return n_filtered
-
     def node_count(self):
         return 1 + sum(child.node_count() for child in self.children if child)
 

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -124,7 +124,6 @@ PYBIND11_MODULE(cpp_boggle, m) {
           py::arg("arena")
       )
       .def("structural_hash", &EvalNode::StructuralHash)
-      .def("filter_below_threshold", &EvalNode::FilterBelowThreshold)
       .def("orderly_bound", &EvalNode::OrderlyBound);
 
   m.def("create_eval_node_arena", &create_eval_node_arena);

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -214,27 +214,6 @@ unsigned int EvalNode::ScoreWithForces(const vector<int>& forces) const {
   }
 }
 
-int EvalNode::FilterBelowThreshold(int min_score) {
-  if (letter_ != CHOICE_NODE) {
-    return 0;
-  }
-  int num_filtered = 0;
-  for (int i = 0; i < children_.size(); i++) {
-    auto child = children_[i];
-    if (!child) {
-      continue;
-    }
-    if (child->bound_ <= min_score) {
-      children_[i] = NULL;
-      num_filtered++;
-    } else {
-      // This casts away the const-ness.
-      num_filtered += ((EvalNode*)child)->FilterBelowThreshold(min_score);
-    }
-  }
-  return num_filtered;
-}
-
 // Borrowed from Boost.ContainerHash via
 // https://stackoverflow.com/a/78509978/388951
 // https://github.com/boostorg/container_hash/blob/ee5285bfa64843a11e29700298c83a37e3132fcd/include/boost/container_hash/hash.hpp#L471
@@ -566,8 +545,8 @@ vector<const EvalNode*> EvalNode::OrderlyForceCell(
     }
   }
 
-  if (!top_choice->cell_) {
-    return {this};
+  if (!top_choice) {
+    return {this};  // XXX this is not the same as what Python does
   }
   assert(top_choice->letter_ == CHOICE_NODE);
 

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -79,8 +79,6 @@ class EvalNode {
   // Must have forces.size() == M * N; set forces[i] = -1 to not force a cell.
   unsigned int ScoreWithForces(const vector<int>& forces) const;
 
-  int FilterBelowThreshold(int min_score);
-
   uint64_t StructuralHash() const;
 
   int8_t letter_;

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -41,19 +41,26 @@ Found unbreakable board for 2520743: perslitesand
     "perslitesand"
   ],
   "elim_level": {},
-  "sum_union": 0,
   "bounds": {
     "0": 6652
   },
   "nodes": {
     "0": 1960065
   },
+  "depth": {
+    "3": 20,
+    "4": 18,
+    "5": 9,
+    "6": 5,
+    "2": 1
+  },
   "boards_to_test": 8078,
   "expanded_to_test": 8078,
   "init_nodes": 1960065,
   "total_nodes": 1960065,
   "freed_nodes": 0,
-  "n_bound": 5
+  "n_bound": 53,
+  "n_force": 12
 }
 Found 12 breaking failure(s):
 cerslatesind

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -51,7 +51,7 @@ Found unbreakable board for 2520743: perslitesand
   "boards_to_test": 8078,
   "expanded_to_test": 8078,
   "init_nodes": 1960065,
-  "total_nodes": 2362580,
+  "total_nodes": 1960065,
   "freed_nodes": 0,
   "n_bound": 5
 }


### PR DESCRIPTION
Fixes #57 
Fixes #58 

Originally, `HybridTreeBreaker` would lift/force a pre-determined number of cells. #37 made it possible for this to vary based on the tree size. Now it makes a decision about when to switch based on the bound of the subtree under consideration. If it's high, we keep forcing more cells. If it's low enough (or we've forced enough cells already), then we switch over to `orderly_bound`.

This has a dramatic effect on hard board classes, particularly 4x4 board classes:

- 500 board test set (b026203) 14000s → 5500s
- best class (19005578): 4.28GB / 4438.13s → 1254s / 4.75GB

So a 2-3x speedup without too much of a RAM penalty. The effect is much smaller for 3x4 boards.

In practice, this forces way more cells than I ever let it before. It would force all 16 cells if I didn't put a cap. This wouldn't have worked before, but thanks to #57 the memory penalty is much lower for more forces than it used to be.

I don't think score is exactly the right way to determine when to switch to `orderly_bound`, but this is a big enough improvement that I don't want to sweat the details.