### PR TITLE
Push and pop arena

### DIFF
--- a/boggle/arena.py
+++ b/boggle/arena.py
@@ -14,6 +14,9 @@ class PyArena:
     def num_nodes(self):
         return self.count
 
+    def bytes_allocated(self):
+        return self.count * 32
+
     def new_node_with_capacity(self, n: int):
         from boggle.eval_node import ROOT_NODE, SumNode
 
@@ -29,6 +32,12 @@ class PyArena:
 
     def add_node(self, node):
         self.count += 1
+
+    def save_level(self):
+        return (0, 0)
+
+    def reset_level(self, level):
+        pass
 
 
 def create_eval_node_arena_py():

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -139,7 +139,6 @@ def break_worker(task: str | int):
         summary = {"id": task, **details.asdict()}
         if args.omit_times:
             del summary["elapsed_s"]
-            del summary["free_time_s"]
             del summary["secs_by_level"]
         out.write(json.dumps(summary))
         out.write("\n")

--- a/boggle/breaker_test.py
+++ b/boggle/breaker_test.py
@@ -67,9 +67,9 @@ def test_breaker(is_python):
             "depth": {2: 3},
             "boards_to_test": 7,
             "init_nodes": 1186,
-            "total_nodes": 1186,
-            "freed_nodes": 0,
-            "free_time_s": 0.0,
+            "total_nodes": 1864,
+            "tree_bytes": 37952,
+            "total_bytes": 59648,
             "n_bound": 3,
             "n_force": 1,
         }

--- a/cpp/arena.cc
+++ b/cpp/arena.cc
@@ -12,8 +12,11 @@ unique_ptr<EvalNodeArena> create_eval_node_arena() {
 }
 
 void EvalNodeArena::AddBuffer() {
-  char* buf = new char[EVAL_NODE_ARENA_BUFFER_SIZE];
-  buffers_.push_back(buf);
+  if (cur_buffer_ == buffers_.size() - 1) {
+    char* buf = new char[EVAL_NODE_ARENA_BUFFER_SIZE];
+    buffers_.push_back(buf);
+  }
+  cur_buffer_++;
   tip_ = 0;
 }
 
@@ -31,4 +34,16 @@ SumNode* EvalNodeArena::NewRootNodeWithCapacity(uint8_t capacity) {
   root->points_ = 0;
   root->bound_ = 0;
   return root;
+}
+
+pair<int, int> EvalNodeArena::SaveLevel() { return {cur_buffer_, tip_}; }
+
+void EvalNodeArena::ResetLevel(pair<int, int> level) {
+  auto [new_cur_buffer, new_tip] = level;
+  assert(new_cur_buffer <= cur_buffer_);
+  if (new_cur_buffer == cur_buffer_) {
+    assert(new_tip <= tip_);
+  }
+  cur_buffer_ = new_cur_buffer;
+  tip_ = new_tip;
 }

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -135,5 +135,8 @@ PYBIND11_MODULE(cpp_boggle, m) {
           &EvalNodeArena::NewRootNodeWithCapacity,
           py::return_value_policy::reference
       )
-      .def("num_nodes", &EvalNodeArena::NumNodes);
+      .def("save_level", &EvalNodeArena::SaveLevel)
+      .def("reset_level", &EvalNodeArena::ResetLevel)
+      .def("num_nodes", &EvalNodeArena::NumNodes)
+      .def("bytes_allocated", &EvalNodeArena::BytesAllocated);
 }

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -56,8 +56,9 @@ Found unbreakable board for 2520743: perslitesand
   },
   "boards_to_test": 8078,
   "init_nodes": 2641103,
-  "total_nodes": 2641103,
-  "freed_nodes": 0,
+  "total_nodes": 4053634,
+  "tree_bytes": 67108864,
+  "total_bytes": 134217728,
   "n_bound": 53,
   "n_force": 12
 }


### PR DESCRIPTION
Closes #81

This re-uses the same arena across a breaking run. This should require fewer allocations and deallocations, and is a prerequisite for #78, which would dramatically lower memory usage.

Running

```
/usr/bin/time -l poetry run python -m boggle.break_all 'aeijou bcdfgmpqvwxz hklnrsty' 3500 --size 44 --board_id 19005578 --log_per_board_stats --switchover_score 8000
```

before and after this change shows ~10% lower memory usage and ~0% change in performance.