### PR TITLE
Bitpack SumNode

### DIFF
--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -102,7 +102,7 @@ PYBIND11_MODULE(cpp_boggle, m) {
 
   py::class_<SumNode>(m, "SumNode")
       .def_readonly("letter", &SumNode::letter_)
-      .def_readonly("bound", &SumNode::bound_)
+      .def_property_readonly("bound", &SumNode::Bound)
       .def_readonly("points", &SumNode::points_)
       .def("node_count", &SumNode::NodeCount)
       .def("add_word", &SumNode::AddWord, py::return_value_policy::reference)

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -31,11 +31,11 @@ class SumNode {
       EvalNodeArena& arena
   );
 
+  uint32_t bound_ : 24;
   int8_t letter_;
   uint16_t points_;
   uint8_t num_children_;
   uint8_t capacity_;
-  uint32_t bound_;
   ChoiceNode* children_[];
 
   static const int8_t ROOT_NODE = -2;
@@ -51,6 +51,7 @@ class SumNode {
   void SetChildrenFromVector(const vector<ChoiceNode*>& children);
 
   int NodeCount() const;
+  uint32_t Bound() const { return bound_; }
 
   tuple<vector<pair<int, string>>, vector<int>, vector<int>> OrderlyBound(
       int cutoff,

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -59,9 +59,10 @@ const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool de
   root_ = NULL;
   // arena.PrintStats();
 
-  /*
   // This can be used to investigate the layout of EvalNode.
-  cout << "sizeof(EvalNode) = " << sizeof(EvalNode) << endl;
+  cout << "sizeof(SumNode) = " << sizeof(SumNode) << endl;
+  cout << "sizeof(ChoiceNode) = " << sizeof(ChoiceNode) << endl;
+  /*
   cout << "root: " << (uintptr_t)root << endl;
   auto r = (uintptr_t)root;
   cout << "root->letter_: " << (uintptr_t)(&root->letter_) - r << endl;

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -60,9 +60,9 @@ const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool de
   // arena.PrintStats();
 
   // This can be used to investigate the layout of EvalNode.
+  /*
   cout << "sizeof(SumNode) = " << sizeof(SumNode) << endl;
   cout << "sizeof(ChoiceNode) = " << sizeof(ChoiceNode) << endl;
-  /*
   cout << "root: " << (uintptr_t)root << endl;
   auto r = (uintptr_t)root;
   cout << "root->letter_: " << (uintptr_t)(&root->letter_) - r << endl;


### PR DESCRIPTION
Fixes #84 

Before/after:

- `sizeof(SumNode)`: 16 → 8
- `sizeof(ChoiceNode)`: 8 → 8

This is at least a 15% memory savings on its own. This was considerably easier after #88 reduced the number of fields in each structure. (Previously both node types had `letter_` and `cell_`.)