### PR TITLE
Hill climbing optimization & code cleanup

### DIFF
--- a/boggle/arena.py
+++ b/boggle/arena.py
@@ -8,9 +8,6 @@ class PyArena:
     def __init__(self):
         self.count = 0
 
-    def free_the_children(self):
-        pass
-
     def num_nodes(self):
         return self.count
 

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -23,7 +23,7 @@ from boggle.board_id import from_board_id, is_canonical_board_id, parse_classes
 from boggle.boggler import PyBoggler
 from boggle.breaker import HybridTreeBreaker
 from boggle.dimensional_bogglers import (
-    BucketBogglers,
+    cpp_bucket_boggler,
     cpp_orderly_tree_builder,
 )
 from boggle.ibucket_breaker import IBucketBreaker
@@ -182,10 +182,7 @@ def get_breaker(args) -> BreakingBundle:
             log_breaker_progress=args.log_breaker_progress,
         )
     elif args.breaker == "ibuckets":
-        if args.python:
-            etb = PyBucketBoggler(t, dims)
-        else:
-            etb = BucketBogglers[dims](t)
+        etb = (PyBucketBoggler if args.python else cpp_bucket_boggler)(t, dims)
         breaker = IBucketBreaker(
             etb,
             dims,

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -186,7 +186,13 @@ def get_breaker(args) -> BreakingBundle:
             etb = PyBucketBoggler(t, dims)
         else:
             etb = BucketBogglers[dims](t)
-        breaker = IBucketBreaker(etb, dims, best_score, num_splits=args.num_splits)
+        breaker = IBucketBreaker(
+            etb,
+            dims,
+            best_score,
+            num_splits=args.num_splits,
+            log_breaker_progress=args.log_breaker_progress,
+        )
     else:
         raise ValueError(args.breaker)
     return BreakingBundle(trie=t, etb=etb, boggler=boggler, breaker=breaker)

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -78,7 +78,6 @@ class HybridTreeBreaker:
         self.boggler = boggler
         self.best_score = best_score
         self.details_ = None
-        self.elim_ = 0
         self.orig_reps_ = 0
         self.dims = dims
         self.split_order = SPLIT_ORDER[dims]
@@ -109,7 +108,6 @@ class HybridTreeBreaker:
             n_bound=0,
             n_force=0,
         )
-        self.elim_ = 0
         self.orig_reps_ = self.details_.num_reps = self.etb.NumReps()
         start_time_s = time.time()
         arena = self.etb.create_arena()

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -109,16 +109,11 @@ class HybridTreeBreaker:
             n_bound=0,
             n_force=0,
         )
-        self.mark = 1  # New mark for a fresh EvalTree
         self.elim_ = 0
         self.orig_reps_ = self.details_.num_reps = self.etb.NumReps()
         start_time_s = time.time()
         arena = self.etb.create_arena()
         tree = self.etb.BuildTree(arena)
-        # num_children, num_nodes, num_singles = size_stats(tree)
-        # print(num_children)
-        # print(num_singles)
-        # print(num_nodes)
         num_nodes = arena.num_nodes()
         if self.log_breaker_progress:
             print(f"root {tree.bound=}, {num_nodes} nodes")

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -101,9 +101,7 @@ def hillclimb(task: int):
     while True:
         num_iter += 1
         ns = {sym.canonicalize(n) for seed in pool for n in neighbors(seed)}
-        scores: list[tuple[int, str]] = []
-        for n in ns:
-            scores.append((get_score(n), n))
+        scores = [(get_score(n), n) for n in ns]
         scores.sort(reverse=True)
         scores = scores[: args.pool_size]
         print(f"#{me} {num_iter=}: {max(scores)=} {min(scores)=}")

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -86,8 +86,8 @@ def hillclimb(task: int):
     @functools.cache
     def get_score(bd: str):
         # This is a convenient place to make adjustments to the score, e.g.
-        # to require a "q" on the board or to exclude high-scoring boareds to test
-        # whether hill climbing can find other boareds in their absence.
+        # to require a "q" on the board or to exclude high-scoring boards to test
+        # whether hill climbing can find other boards in their absence.
         # if "q" not in bd:
         #     return 0
         score = boggler.score(bd)

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -82,8 +82,8 @@ def hillclimb(task: int):
         sym.canonicalize("".join(chr(x) for x in initial_board(num_lets)))
         for _ in range(args.pool_size)
     ]
-    score_cache = dict[str, int]()
 
+    @functools.cache
     def get_score(bd: str):
         # This is a convenient place to make adjustments to the score, e.g.
         # to require a "q" on the board or to exclude high-scoring boareds to test
@@ -93,13 +93,9 @@ def hillclimb(task: int):
         score = boggler.score(bd)
         # if score > 3512:
         #     score = 1000
-        score_cache[bd] = score
         return score
 
-    for bd in pool:
-        get_score(bd)
-
-    best_score = max(score_cache.values())
+    best_score = max(get_score(bd) for bd in pool)
 
     num_iter = 0
     while True:
@@ -107,8 +103,7 @@ def hillclimb(task: int):
         ns = {sym.canonicalize(n) for seed in pool for n in neighbors(seed)}
         scores: list[tuple[int, str]] = []
         for n in ns:
-            score = score_cache.get(n) or get_score(n)
-            scores.append((score, n))
+            scores.append((get_score(n), n))
         scores.sort(reverse=True)
         scores = scores[: args.pool_size]
         print(f"#{me} {num_iter=}: {max(scores)=} {min(scores)=}")

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -87,8 +87,11 @@ def hillclimb(task: int):
     score_cache = dict[str, int]()
 
     def get_score(bd: str):
-        if "q" not in bd:
-            return 0
+        # This is a convenient place to make adjustments to the score, e.g.
+        # to require a "q" on the board or to exclude high-scoring boareds to test
+        # whether hill climbing can find other boareds in their absence.
+        # if "q" not in bd:
+        #     return 0
         score = boggler.score(bd)
         # if score > 3512:
         #     score = 1000

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -20,7 +20,7 @@ from collections import Counter
 
 from boggle.anneal import initial_board
 from boggle.args import add_standard_args, get_trie_and_boggler_from_args
-from boggle.symmetry import canonicalize, list_to_matrix
+from boggle.symmetry import canonicalize_board
 from boggle.trie import LETTER_A
 
 
@@ -76,12 +76,11 @@ def hillclimb(task: int):
     num_lets = w * h
 
     @functools.cache
-    def canonicalize_str(board: str) -> str:
-        bd = canonicalize(list_to_matrix(board))
-        return "".join(str(x) for row in bd for x in row)
+    def canonicalize_memo(board: str) -> str:
+        return canonicalize_board(board)
 
     pool = [
-        canonicalize_str("".join(chr(x) for x in initial_board(num_lets)))
+        canonicalize_memo("".join(chr(x) for x in initial_board(num_lets)))
         for _ in range(args.pool_size)
     ]
     score_cache = dict[str, int]()
@@ -106,7 +105,7 @@ def hillclimb(task: int):
     num_iter = 0
     while True:
         num_iter += 1
-        ns = {canonicalize_str(n) for seed in pool for n in neighbors(seed)}
+        ns = {canonicalize_memo(n) for seed in pool for n in neighbors(seed)}
         scores: list[tuple[int, str]] = []
         for n in ns:
             score = score_cache.get(n) or get_score(n)

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -18,9 +18,10 @@ import random
 import time
 from collections import Counter
 
+from cpp_boggle import Symmetry
+
 from boggle.anneal import initial_board
 from boggle.args import add_standard_args, get_trie_and_boggler_from_args
-from boggle.symmetry import canonicalize_board
 from boggle.trie import LETTER_A
 
 
@@ -75,12 +76,10 @@ def hillclimb(task: int):
     boggler = hillclimb.boggler
     num_lets = w * h
 
-    @functools.cache
-    def canonicalize_memo(board: str) -> str:
-        return canonicalize_board(board)
+    sym = Symmetry(w, h)
 
     pool = [
-        canonicalize_memo("".join(chr(x) for x in initial_board(num_lets)))
+        sym.canonicalize("".join(chr(x) for x in initial_board(num_lets)))
         for _ in range(args.pool_size)
     ]
     score_cache = dict[str, int]()
@@ -105,7 +104,7 @@ def hillclimb(task: int):
     num_iter = 0
     while True:
         num_iter += 1
-        ns = {canonicalize_memo(n) for seed in pool for n in neighbors(seed)}
+        ns = {sym.canonicalize(n) for seed in pool for n in neighbors(seed)}
         scores: list[tuple[int, str]] = []
         for n in ns:
             score = score_cache.get(n) or get_score(n)

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -5,7 +5,7 @@ all the boards within an edit distance of 1. It then chooses the highest
 scoring of these boards plus the current pool as the pool for the next round.
 
 Larger pool sizes will increase the odds of making it over to the next peak
-at the cost of more computation per iteratin.
+at the cost of more computation per iteration.
 
 This might be an implementation of this algorithm:
 https://en.wikipedia.org/wiki/Greedy_randomized_adaptive_search_procedure

--- a/boggle/ibucket_breaker.py
+++ b/boggle/ibucket_breaker.py
@@ -130,7 +130,11 @@ class IBucketBreaker:
         elapsed_s = time.time() - start_s
         if self.log_breaker_progress:
             indent = " " * level
-            sys.stderr.write(f"{indent}{num}/{out_of} {ub} {self.bb.as_string()}\n")
+            d = self.bb.Details()
+            incomp = " (incomplete)" if ub >= self.best_score else ""
+            sys.stderr.write(
+                f"{indent}{num}/{out_of} {ub}{incomp} (max={d.max_nomark}, sum={d.sum_union}) {self.bb.as_string()}\n"
+            )
         self.details_.secs_by_level[level] += elapsed_s
         if level == 0:
             # self.details_.root_score_bailout = (ub, self.bb.Details().bailout_cell)

--- a/boggle/ibucket_breaker.py
+++ b/boggle/ibucket_breaker.py
@@ -6,6 +6,7 @@ https://www.danvk.org/2025/02/10/boggle34.html#how-did-i-find-the-optimal-3x3-bo
 This strategy uses almost no memory, but it's considerably slower than HybridTreeBreaker.
 """
 
+import sys
 import time
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -39,6 +40,7 @@ class IBucketBreaker:
         best_score: int,
         *,
         num_splits: int,
+        log_breaker_progress: bool,
     ):
         self.bb = boggler
         self.best_score = best_score
@@ -48,6 +50,7 @@ class IBucketBreaker:
         self.dims = dims
         self.split_order = SPLIT_ORDER[dims]
         self.num_splits = num_splits
+        self.log_breaker_progress = log_breaker_progress
 
     def SetBoard(self, board: str):
         return self.bb.ParseBoard(board)
@@ -125,6 +128,9 @@ class IBucketBreaker:
         start_s = time.time()
         ub = self.bb.UpperBound(self.best_score)
         elapsed_s = time.time() - start_s
+        if self.log_breaker_progress:
+            indent = " " * level
+            sys.stderr.write(f"{indent}{num}/{out_of} {ub} {self.bb.as_string()}\n")
         self.details_.secs_by_level[level] += elapsed_s
         if level == 0:
             # self.details_.root_score_bailout = (ub, self.bb.Details().bailout_cell)

--- a/boggle/symmetry.py
+++ b/boggle/symmetry.py
@@ -60,3 +60,15 @@ def canonicalize[T](mat: list[list[T]]):
 
 def canonicalize_board(bd: str):
     return mat_to_str(canonicalize(list_to_matrix(bd)))
+
+
+class Symmetry:
+    """This looks strange, but it matches the C++ interface."""
+
+    def __init__(self, w: int, h: int):
+        self.w = w
+        self.h = h
+
+    def canonicalize(self, board: str):
+        assert len(board) == self.w * self.h
+        return canonicalize_board(board)

--- a/boggle/symmetry.py
+++ b/boggle/symmetry.py
@@ -3,7 +3,6 @@
 # TODO: this may not be in sync w/ board_id.py
 
 from itertools import chain
-from typing import Sequence
 
 from boggle.dimensional_bogglers import LEN_TO_DIMS
 
@@ -23,11 +22,6 @@ def flip_x[T](mat: list[list[T]]):
 def flip_y[T](mat: list[list[T]]):
     """Flip an NxM matrix along the y-axis."""
     return [row[::-1] for row in mat]
-
-
-def transpose[T](mat: list[list[T]]):
-    """Transpose an NxM matrix."""
-    return [[mat[i][j] for i in range(len(mat))] for j in range(len(mat[0]))]
 
 
 def all_symmetries[T](mat: list[list[T]]):
@@ -62,33 +56,3 @@ def list_to_matrix(letters):
 def canonicalize[T](mat: list[list[T]]):
     """Return the canonical form of a 2D matrix."""
     return min(chain([mat], all_symmetries(mat)), key=mat_to_str)
-
-
-def is_canonical(mat: list[list]):
-    me = mat_to_str(mat)
-    for sym in all_symmetries(mat):
-        if mat_to_str(sym) < me:
-            return False
-    return True
-
-
-def find_symmetry_ids(mat: list[list]):
-    """Find all symmetries of a 2D matrix."""
-    this_str = mat_to_str(mat)
-    return [
-        i for i, sym in enumerate(all_symmetries(mat)) if mat_to_str(sym) == this_str
-    ]
-
-
-def apply_symmetry_ids[T](mat: list[list[T]], ids: Sequence[int]):
-    syms = all_symmetries(mat)
-    return [syms[i] for i in ids]
-
-
-def is_canonical_within_group(mat: list[list], ids: Sequence[int]):
-    """Return the canonical form of a 2D matrix within its symmetry group."""
-    me = mat_to_str(mat)
-    for sym in apply_symmetry_ids(mat, ids):
-        if mat_to_str(sym) < me:
-            return False
-    return True

--- a/boggle/symmetry.py
+++ b/boggle/symmetry.py
@@ -56,3 +56,7 @@ def list_to_matrix(letters):
 def canonicalize[T](mat: list[list[T]]):
     """Return the canonical form of a 2D matrix."""
     return min(chain([mat], all_symmetries(mat)), key=mat_to_str)
+
+
+def canonicalize_board(bd: str):
+    return mat_to_str(canonicalize(list_to_matrix(bd)))

--- a/boggle/symmetry_test.py
+++ b/boggle/symmetry_test.py
@@ -141,3 +141,7 @@ def test_canonicalize_board():
     assert canonicalize_board("perslatgsineters") == "perslatgsineters"
     assert canonicalize_board("plsteaiertnrsges") == "perslatgsineters"
     assert canonicalize_board("srepgtalenissret") == "perslatgsineters"
+    assert canonicalize_board("sretenisgtalsrep") == "perslatgsineters"
+
+    assert canonicalize_board("dnisetalsrep") == "dnisetalsrep"
+    assert canonicalize_board("perslatesind") == "dnisetalsrep"

--- a/boggle/symmetry_test.py
+++ b/boggle/symmetry_test.py
@@ -1,7 +1,9 @@
-from cpp_boggle import Symmetry
+import pytest
+from cpp_boggle import Symmetry as CppSymmetry
 from inline_snapshot import snapshot
 
 from boggle.symmetry import (
+    Symmetry,
     all_symmetries,
     canonicalize,
     canonicalize_board,
@@ -148,6 +150,17 @@ def test_canonicalize_board():
     assert canonicalize_board("perslatesind") == "dnisetalsrep"
 
 
-def test_symmetry_cpp():
-    sym = Symmetry(4, 4)
+@pytest.mark.parametrize("SymmetryClass", [Symmetry, CppSymmetry])
+def test_cpp_equivalence44(SymmetryClass):
+    sym = SymmetryClass(4, 4)
     assert sym.canonicalize("perslatgsineters") == "perslatgsineters"
+    assert sym.canonicalize("plsteaiertnrsges") == "perslatgsineters"
+    assert sym.canonicalize("srepgtalenissret") == "perslatgsineters"
+    assert sym.canonicalize("sretenisgtalsrep") == "perslatgsineters"
+
+
+@pytest.mark.parametrize("SymmetryClass", [Symmetry, CppSymmetry])
+def test_cpp_equivalence34(SymmetryClass):
+    sym = SymmetryClass(3, 4)
+    assert sym.canonicalize("dnisetalsrep") == "dnisetalsrep"
+    assert sym.canonicalize("perslatesind") == "dnisetalsrep"

--- a/boggle/symmetry_test.py
+++ b/boggle/symmetry_test.py
@@ -3,6 +3,7 @@ from inline_snapshot import snapshot
 from boggle.symmetry import (
     all_symmetries,
     canonicalize,
+    canonicalize_board,
     flip_x,
     flip_y,
     list_to_matrix,
@@ -128,3 +129,15 @@ def test_canonicalize_34():
     mat = list_to_matrix(board)
     assert mat_to_str(mat) == board
     assert mat_to_str(canonicalize(mat)) == snapshot("berslatepind")
+
+
+# P E R S
+# L A T G
+# S I N E
+# T E R S
+
+
+def test_canonicalize_board():
+    assert canonicalize_board("perslatgsineters") == "perslatgsineters"
+    assert canonicalize_board("plsteaiertnrsges") == "perslatgsineters"
+    assert canonicalize_board("srepgtalenissret") == "perslatgsineters"

--- a/boggle/symmetry_test.py
+++ b/boggle/symmetry_test.py
@@ -1,3 +1,4 @@
+from cpp_boggle import Symmetry
 from inline_snapshot import snapshot
 
 from boggle.symmetry import (
@@ -145,3 +146,8 @@ def test_canonicalize_board():
 
     assert canonicalize_board("dnisetalsrep") == "dnisetalsrep"
     assert canonicalize_board("perslatesind") == "dnisetalsrep"
+
+
+def test_symmetry_cpp():
+    sym = Symmetry(4, 4)
+    assert sym.canonicalize("perslatgsineters") == "perslatgsineters"

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ c++ -Wall -shared -std=c++20 -fPIC -march=native \
     -Wshadow \
     -O3 \
     $(poetry run python -m pybind11 --includes) \
-    cpp_boggle.cc trie.cc arena.cc eval_node.cc \
+    cpp_boggle.cc trie.cc arena.cc eval_node.cc symmetry.cc \
     -o ../cpp_boggle$(python3-config --extension-suffix) \
     $EXTRA_FLAGS
 

--- a/cpp/arena.cc
+++ b/cpp/arena.cc
@@ -2,6 +2,13 @@
 
 #include "eval_node.h"
 
+EvalNodeArena::~EvalNodeArena() {
+  for (auto buffer : buffers_) {
+    delete[] buffer;
+  }
+  buffers_.clear();
+}
+
 void EvalNodeArena::PrintStats() {
   cout << "num_buffers: " << buffers_.size() << endl;
   cout << "tip: " << tip_ << endl;

--- a/cpp/arena.h
+++ b/cpp/arena.h
@@ -22,7 +22,7 @@ const uint64_t EVAL_NODE_ARENA_BUFFER_SIZE = 64 << 20;
 class EvalNodeArena {
  public:
   EvalNodeArena() : num_nodes_(0), cur_buffer_(-1), tip_(EVAL_NODE_ARENA_BUFFER_SIZE) {}
-  ~EvalNodeArena() { FreeTheChildren(); }
+  ~EvalNodeArena();
 
   int NumNodes() { return num_nodes_; }
   uint64_t BytesAllocated() { return buffers_.size() * EVAL_NODE_ARENA_BUFFER_SIZE; }
@@ -41,13 +41,6 @@ class EvalNodeArena {
   void PrintStats();
 
  private:
-  void FreeTheChildren() {
-    for (auto buffer : buffers_) {
-      delete[] buffer;
-    }
-    buffers_.clear();
-  }
-
   void AddBuffer();
   vector<char*> buffers_;
   int num_nodes_;

--- a/cpp/arena.h
+++ b/cpp/arena.h
@@ -24,16 +24,6 @@ class EvalNodeArena {
   EvalNodeArena() : num_nodes_(0), cur_buffer_(-1), tip_(EVAL_NODE_ARENA_BUFFER_SIZE) {}
   ~EvalNodeArena() { FreeTheChildren(); }
 
-  void FreeTheChildren() {
-    // cout << "Freeing " << buffers_.size() << " buffers" << endl;
-    for (auto buffer : buffers_) {
-      // cout << "Freeing " << node << endl;
-      delete[] buffer;
-      // cout << "(done)" << endl;
-    }
-    buffers_.clear();
-  }
-
   int NumNodes() { return num_nodes_; }
   uint64_t BytesAllocated() { return buffers_.size() * EVAL_NODE_ARENA_BUFFER_SIZE; }
 
@@ -51,6 +41,13 @@ class EvalNodeArena {
   void PrintStats();
 
  private:
+  void FreeTheChildren() {
+    for (auto buffer : buffers_) {
+      delete[] buffer;
+    }
+    buffers_.clear();
+  }
+
   void AddBuffer();
   vector<char*> buffers_;
   int num_nodes_;

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -11,6 +11,7 @@ using std::vector;
 #include "eval_node.h"
 #include "ibuckets.h"
 #include "orderly_tree_builder.h"
+#include "symmetry.h"
 #include "trie.h"
 
 // See https://stackoverflow.com/a/47749076/388951
@@ -138,4 +139,8 @@ PYBIND11_MODULE(cpp_boggle, m) {
       .def("reset_level", &EvalNodeArena::ResetLevel)
       .def("num_nodes", &EvalNodeArena::NumNodes)
       .def("bytes_allocated", &EvalNodeArena::BytesAllocated);
+
+  py::class_<Symmetry>(m, "Symmetry")
+      .def(py::init<int, int>())
+      .def("canonicalize", &Symmetry::Canonicalize);
 }

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -129,7 +129,6 @@ PYBIND11_MODULE(cpp_boggle, m) {
   m.def("create_eval_node_arena", &create_eval_node_arena);
   py::class_<EvalNodeArena>(m, "EvalNodeArena")
       .def(py::init())
-      .def("free_the_children", &EvalNodeArena::FreeTheChildren)
       .def(
           "new_root_node_with_capacity",
           &EvalNodeArena::NewRootNodeWithCapacity,

--- a/cpp/symmetry.cc
+++ b/cpp/symmetry.cc
@@ -3,7 +3,7 @@
 std::string Symmetry::Canonicalize(const std::string& board) {
   if (board.size() != w_ * h_) return "";
   std::string best = board;
-  std::string bd;
+  std::string bd = board;
   bd = FlipX(board);
   if (bd < best) best = bd;
   bd = FlipY(bd);
@@ -26,7 +26,6 @@ std::string Symmetry::Canonicalize(const std::string& board) {
 }
 
 std::string Symmetry::FlipY(const std::string& bd) {
-  if (bd.size() != w_ * h_) return "";
   std::string out(w_ * h_, ' ');
   for (int y = 0; y < h_; y++) {
     for (int x = 0; x < w_; x++) {
@@ -37,7 +36,6 @@ std::string Symmetry::FlipY(const std::string& bd) {
 }
 
 std::string Symmetry::FlipX(const std::string& bd) {
-  if (bd.size() != w_ * h_) return "";
   std::string out(w_ * h_, ' ');
   for (int x = 0; x < w_; x++) {
     for (int y = 0; y < h_; y++) {
@@ -48,7 +46,6 @@ std::string Symmetry::FlipX(const std::string& bd) {
 }
 
 std::string Symmetry::Rotate90CW(const std::string& bd) {
-  if (w_ != h_) return "";  // rotation only works for square boards!
   std::string out(w_ * h_, ' ');
   for (int x = 0; x < w_; x++) {
     for (int y = 0; y < h_; y++) {

--- a/cpp/symmetry.cc
+++ b/cpp/symmetry.cc
@@ -14,21 +14,21 @@ bool Symmetry::AllSymmetries(
   if (board.size() != w_ * h_) return false;
   analogues->clear();
   std::string bd;
-  bd = FlipLeftRight(board);
+  bd = FlipX(board);
   if (board != bd) analogues->push_back(bd);
-  bd = FlipTopBottom(bd);
+  bd = FlipY(bd);
   if (board != bd) analogues->push_back(bd);
-  bd = FlipLeftRight(bd);
+  bd = FlipX(bd);
   if (board != bd) analogues->push_back(bd);
 
   if (w_ == h_) {
     bd = Rotate90CW(board);
     if (board != bd) analogues->push_back(bd);
-    bd = FlipLeftRight(bd);
+    bd = FlipX(bd);
     if (board != bd) analogues->push_back(bd);
-    bd = FlipTopBottom(bd);
+    bd = FlipY(bd);
     if (board != bd) analogues->push_back(bd);
-    bd = FlipLeftRight(bd);
+    bd = FlipX(bd);
     if (board != bd) analogues->push_back(bd);
   }
 
@@ -36,7 +36,7 @@ bool Symmetry::AllSymmetries(
   return true;
 }
 
-std::string Symmetry::FlipTopBottom(const std::string& bd) {
+std::string Symmetry::FlipY(const std::string& bd) {
   if (bd.size() != w_ * h_) return "";
   std::string out(w_ * h_, ' ');
   for (int y = 0; y < h_; y++) {
@@ -47,7 +47,7 @@ std::string Symmetry::FlipTopBottom(const std::string& bd) {
   return out;
 }
 
-std::string Symmetry::FlipLeftRight(const std::string& bd) {
+std::string Symmetry::FlipX(const std::string& bd) {
   if (bd.size() != w_ * h_) return "";
   std::string out(w_ * h_, ' ');
   for (int x = 0; x < w_; x++) {

--- a/cpp/symmetry.cc
+++ b/cpp/symmetry.cc
@@ -1,0 +1,70 @@
+#include "symmetry.h"
+
+std::string Symmetry::Canonicalize(const std::string& board) {
+  std::vector<std::string> rots;
+  if (!AllSymmetries(board, &rots)) return "";
+  rots.push_back(board);
+  sort(rots.begin(), rots.end());
+  return rots[0];
+}
+
+bool Symmetry::AllSymmetries(
+    const std::string& board, std::vector<std::string>* analogues
+) {
+  if (board.size() != w_ * h_) return false;
+  analogues->clear();
+  std::string bd;
+  bd = FlipLeftRight(board);
+  if (board != bd) analogues->push_back(bd);
+  bd = FlipTopBottom(bd);
+  if (board != bd) analogues->push_back(bd);
+  bd = FlipLeftRight(bd);
+  if (board != bd) analogues->push_back(bd);
+
+  if (w_ == h_) {
+    bd = Rotate90CW(board);
+    if (board != bd) analogues->push_back(bd);
+    bd = FlipLeftRight(bd);
+    if (board != bd) analogues->push_back(bd);
+    bd = FlipTopBottom(bd);
+    if (board != bd) analogues->push_back(bd);
+    bd = FlipLeftRight(bd);
+    if (board != bd) analogues->push_back(bd);
+  }
+
+  analogues->erase(std::unique(analogues->begin(), analogues->end()), analogues->end());
+  return true;
+}
+
+std::string Symmetry::FlipTopBottom(const std::string& bd) {
+  if (bd.size() != w_ * h_) return "";
+  std::string out(w_ * h_, ' ');
+  for (int y = 0; y < h_; y++) {
+    for (int x = 0; x < w_; x++) {
+      out[Id(x, y)] = bd[Id(x, h_ - 1 - y)];
+    }
+  }
+  return out;
+}
+
+std::string Symmetry::FlipLeftRight(const std::string& bd) {
+  if (bd.size() != w_ * h_) return "";
+  std::string out(w_ * h_, ' ');
+  for (int x = 0; x < w_; x++) {
+    for (int y = 0; y < h_; y++) {
+      out[Id(x, y)] = bd[Id(w_ - 1 - x, y)];
+    }
+  }
+  return out;
+}
+
+std::string Symmetry::Rotate90CW(const std::string& bd) {
+  if (w_ != h_) return "";  // rotation only works for square boards!
+  std::string out(w_ * h_, ' ');
+  for (int x = 0; x < w_; x++) {
+    for (int y = 0; y < h_; y++) {
+      out[Id(w_ - 1 - y, x)] = bd[Id(x, y)];
+    }
+  }
+  return out;
+}

--- a/cpp/symmetry.cc
+++ b/cpp/symmetry.cc
@@ -1,39 +1,28 @@
 #include "symmetry.h"
 
 std::string Symmetry::Canonicalize(const std::string& board) {
-  std::vector<std::string> rots;
-  if (!AllSymmetries(board, &rots)) return "";
-  rots.push_back(board);
-  sort(rots.begin(), rots.end());
-  return rots[0];
-}
-
-bool Symmetry::AllSymmetries(
-    const std::string& board, std::vector<std::string>* analogues
-) {
-  if (board.size() != w_ * h_) return false;
-  analogues->clear();
+  if (board.size() != w_ * h_) return "";
+  std::string best = board;
   std::string bd;
   bd = FlipX(board);
-  if (board != bd) analogues->push_back(bd);
+  if (bd < best) best = bd;
   bd = FlipY(bd);
-  if (board != bd) analogues->push_back(bd);
+  if (bd < best) best = bd;
   bd = FlipX(bd);
-  if (board != bd) analogues->push_back(bd);
+  if (bd < best) best = bd;
 
   if (w_ == h_) {
     bd = Rotate90CW(board);
-    if (board != bd) analogues->push_back(bd);
+    if (bd < best) best = bd;
     bd = FlipX(bd);
-    if (board != bd) analogues->push_back(bd);
+    if (bd < best) best = bd;
     bd = FlipY(bd);
-    if (board != bd) analogues->push_back(bd);
+    if (bd < best) best = bd;
     bd = FlipX(bd);
-    if (board != bd) analogues->push_back(bd);
+    if (bd < best) best = bd;
   }
 
-  analogues->erase(std::unique(analogues->begin(), analogues->end()), analogues->end());
-  return true;
+  return best;
 }
 
 std::string Symmetry::FlipY(const std::string& bd) {

--- a/cpp/symmetry.h
+++ b/cpp/symmetry.h
@@ -16,8 +16,8 @@ class Symmetry {
   bool AllSymmetries(const std::string& board, std::vector<std::string>* analogues);
 
   // Basic symmetries applied to board strings
-  std::string FlipTopBottom(const std::string& bd);
-  std::string FlipLeftRight(const std::string& bd);
+  std::string FlipY(const std::string& bd);
+  std::string FlipX(const std::string& bd);
   std::string Rotate90CW(const std::string& bd);
 
   // Conversions between indices and coordinates.

--- a/cpp/symmetry.h
+++ b/cpp/symmetry.h
@@ -18,9 +18,9 @@ class Symmetry {
   std::string Rotate90CW(const std::string& bd);
 
   // Conversions between indices and coordinates.
-  inline int Id(int x, int y) { return x * h_ + y; }
-  inline int X(int id) { return id / h_; }
-  inline int Y(int id) { return id % h_; }
+  inline int Id(int x, int y) const { return x * h_ + y; }
+  inline int X(int id) const { return id / h_; }
+  inline int Y(int id) const { return id % h_; }
 
   int w_;
   int h_;

--- a/cpp/symmetry.h
+++ b/cpp/symmetry.h
@@ -12,9 +12,6 @@ class Symmetry {
   std::string Canonicalize(const std::string& board);
 
  private:
-  // Generates all boards in the same symmetry class.
-  bool AllSymmetries(const std::string& board, std::vector<std::string>* analogues);
-
   // Basic symmetries applied to board strings
   std::string FlipY(const std::string& bd);
   std::string FlipX(const std::string& bd);

--- a/cpp/symmetry.h
+++ b/cpp/symmetry.h
@@ -4,18 +4,20 @@
 #include <string>
 #include <vector>
 
+using std::string;
+
 class Symmetry {
  public:
   Symmetry(int w, int h) : w_(w), h_(h) {}
 
   // Returns the canonical version of the board (possibly the input board).
-  std::string Canonicalize(const std::string& board);
+  string Canonicalize(const string& board);
 
  private:
   // Basic symmetries applied to board strings
-  std::string FlipY(const std::string& bd);
-  std::string FlipX(const std::string& bd);
-  std::string Rotate90CW(const std::string& bd);
+  string FlipY(const string& bd);
+  string FlipX(const string& bd);
+  string Rotate90CW(const string& bd);
 
   // Conversions between indices and coordinates.
   inline int Id(int x, int y) const { return x * h_ + y; }

--- a/cpp/symmetry.h
+++ b/cpp/symmetry.h
@@ -1,0 +1,32 @@
+#ifndef SYMMETRY_H
+#define SYMMETRY_H
+
+#include <string>
+#include <vector>
+
+class Symmetry {
+ public:
+  Symmetry(int w, int h) : w_(w), h_(h) {}
+
+  // Returns the canonical version of the board (possibly the input board).
+  std::string Canonicalize(const std::string& board);
+
+ private:
+  // Generates all boards in the same symmetry class.
+  bool AllSymmetries(const std::string& board, std::vector<std::string>* analogues);
+
+  // Basic symmetries applied to board strings
+  std::string FlipTopBottom(const std::string& bd);
+  std::string FlipLeftRight(const std::string& bd);
+  std::string Rotate90CW(const std::string& bd);
+
+  // Conversions between indices and coordinates.
+  inline int Id(int x, int y) { return x * h_ + y; }
+  inline int X(int id) { return id / h_; }
+  inline int Y(int id) { return id % h_; }
+
+  int w_;
+  int h_;
+};
+
+#endif  // SYMMETRY_H


### PR DESCRIPTION
Fixes #85 

- Porting canonicalization to C++ speeds up `hillclimb.py` by something like 15-30%. This code comes from [`board-utils.cc`](https://github.com/danvk/performance-boggle/blob/master/board-utils.cc) in the old performance-boggle repo.
- Caching canonicalization didn't make a difference; I assume the vast majority of time is spent evaluating boards now.
- Deletes a few unused symbols

The before/after for `--strategy ibuckets` is wild:

```
$ poetry run python -m boggle.break_all 'aeijou bcdfgmpqvwxz hklnrsty, corner:aeiosuy bcdfghjklmnpqrtvwxz' 3500 --size 44 --board_id 778329 --log_per_board_stats --switchover_score 8000
(finishes in ~7 seconds)

$ poetry run python -m boggle.break_all 'aeijou bcdfgmpqvwxz hklnrsty, corner:aeiosuy bcdfghjklmnpqrtvwxz' 3500 --size 44 --board_id 778329 --log_per_board_stats --breaker ibuckets
(ran for ~22h before I killed it)
```

So orderly trees and all the tree operations are at least a 10,000x speedup for this board class. Wow!