### PR TITLE
Broader 5x5 support, macro cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: poetry run ruff check
 
     - name: Run cog
-      run: PYTHONPATH=. poetry run cog -P --check cpp/board_class_boggler.h
+      run: PYTHONPATH=. poetry run cog -P --check cpp/*.h
 
     - name: Run clang-format
       run: clang-format --dry-run --Werror cpp/*.{h,cc}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These are the best (and best known) boards with the [ENABLE2K word list].
 - ✅ 3x3: `streaedlp` [545 points], [proven optimal][33] in 2009.
 - ✅ 3x4: `perslatesind` [1651 points], [proven optimal][34] in 2025.
 - ✅ 4x4: `perslatgsineters` [3625 points], proven optimal in 2025. (Details coming soon!)
-- ❓ 5x5: `sepesdsracietilmanesligdr`, 10406 points, found via hill climbing, optimality unknown.
+- ❓ 5x5: `ligdrmanesietildsracsepes`, 10406 points, found via hill climbing, optimality unknown.
 
 The 3x4 board should be read down columns first:
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ $ poetry run python -m boggle.ibucket_solver "lnrsy aeiou chkmpt chkmpt aeiou ln
 
 This also takes a `--print_words` flag that will print all the words that can be found on any board in the board class.
 
-To calculate the upper bound on a board class using 2025 [orderly trees], use `orderly_tree_builder`:
+To calculate the upper bound on a board class using 2025's [orderly trees], use `orderly_tree_builder`:
 
 ```
 $ poetry run python -m boggle.orderly_tree_builder "lnrsy aeiou chkmpt chkmpt aeiou lnrsy lnrsy aeiou bdfgjvwxz"

--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ Here are the results for different wordlists. See [wordlists/README.md](wordlist
   | 3x3 |   | 3x4 |   | 4x4 |   | 5x5
 -- | -- | -- | -- | -- | -- | -- | --
              | **hillclimb** | **global** | **hillclimb** | **global** | **hillclimb** | **global** | **hillclimb**
-**ENABLE2K** | `streaedlp` | `streaedlp` | `perslatesind` | `perslatesind` | `perslatgsineters` | `perslatgsineters` | `sepesdsracietilmanesligdr`
-**NASPA23**  | `lepsartes` | `lepsartes` | `perslatesind` | `perslatesind` | `perslatgsineters` | ? | ?
+**ENABLE2K** | `streaedlp` | `streaedlp` | `perslatesind` | `perslatesind` | `perslatgsineters` | `perslatgsineters` | `ligdrmanesietildsracsepes`
+**NASPA23**  | `lepsartes` | `lepsartes` | `perslatesind` | `perslatesind` | `perslatgsineters` | ? | `ligdrmanesietildsracsepes`
 **OSPD**     | `lepsartes` | `lepsartes` | `perslatesind` | `perslatesind` | `segsrntreiaeslps` | ? | ?
-**YAWL**     | `stleaeprd` | `stleaeprd` | `bindlatesers` | `bindlatesers` | `bestlatepirsseng` | ? | ?
+**YAWL**     | `stleaeprd` | `stleaeprd` | `bindlatesers` | `bindlatesers` | `bestlatepirsseng` | ? | `dplcsseaietrtndsaiesgnmpr`
 **SOWPODS**  | `streaedlb` | `streaedlb` | `drpseiaestng` | `drpseiaestng` | `bestlatepirsseng` | ? | ?
-**TWL06**    | `lepsartes` | `lepsartes` | `perslatesind` | `perslatesind` | `aresstapenildres` | ? | `sepesdsracietilmanesligdr`
+**TWL06**    | `lepsartes` | `lepsartes` | `perslatesind` | `perslatesind` | `aresstapenildres` | ? | `rdgassentmliteicarsdseper`
 
 - "hillclimb" means that this is the best board found using [hill climbing] (`hillclimb.py`).
 - "global" means this is the globally optimal board (`break_all.py`).

--- a/boggle/board_id.py
+++ b/boggle/board_id.py
@@ -173,7 +173,7 @@ def main():
     parser.add_argument(
         "--size",
         type=int,
-        choices=(33, 34, 44),
+        choices=(33, 34, 44, 55),
         default=33,
         help="Size of the boggle board.",
     )
@@ -181,8 +181,8 @@ def main():
 
     args = parser.parse_args()
     w, h = dims = args.size // 10, args.size % 10
-    assert 3 <= w <= 4
-    assert 3 <= h <= 4
+    assert 3 <= w <= 5
+    assert 3 <= h <= 5
     classes = parse_classes(args.classes, dims)
     assert len(classes) == w * h
     num_classes = [len(c) for c in classes]

--- a/boggle/boggler_test.py
+++ b/boggle/boggler_test.py
@@ -32,6 +32,7 @@ def test33(get_trie, Boggler):
     t = get_trie()
     b = Boggler(t, (3, 3))
     assert b.score("abcdefghi") == 20
+    assert b.score("streaedlp") == 545
 
 
 # This tests proper orientation: 3x4 vs 4x3, row- vs. column-major.

--- a/boggle/boggler_test.py
+++ b/boggle/boggler_test.py
@@ -52,6 +52,7 @@ def test34(get_trie, Boggler):
     # G H I
     # J K L
     assert b.score("adgjbehkcfil") == 34
+    assert b.score("perslatesind") == 1651
 
 
 @pytest.mark.parametrize("get_trie, Boggler", PARAMS)
@@ -59,3 +60,11 @@ def test44(get_trie, Boggler):
     t = get_trie()
     b = Boggler(t, (4, 4))
     assert b.score("abcdefghijklmnop") == 18
+    assert b.score("perslatgsineters") == 3625
+
+
+@pytest.mark.parametrize("get_trie, Boggler", PARAMS)
+def test55(get_trie, Boggler):
+    t = get_trie()
+    b = Boggler(t, (5, 5))
+    assert b.score("sepesdsracietilmanesligdr") == 10406

--- a/boggle/boggler_test.py
+++ b/boggle/boggler_test.py
@@ -90,8 +90,8 @@ def test_find_words():
             [11, 14, 15],
             [12, 8, 13, 10],
             [13, 8, 12],
-            [15, 14, 11],
             [15, 11, 14, 13, 10],
+            [15, 14, 11],
         ]
     )
 
@@ -103,8 +103,8 @@ def test_find_words():
     assert three_uniq == snapshot(
         [
             [0, 1, 5, 4],
-            [1, 0, 4, 8, 5],
             [1, 0, 4, 5],
+            [1, 0, 4, 8, 5],
             [1, 5, 0, 4],
             [1, 5, 9, 6],
             [2, 5, 4, 9],
@@ -117,8 +117,8 @@ def test_find_words():
     assert words_uniq == snapshot(
         [
             "abed",
-            "badge",
             "bade",
+            "badge",
             "bead",
             "beef",
             "cede",
@@ -131,9 +131,9 @@ def test_find_words():
     assert three_multi == snapshot(
         [
             [0, 1, 5, 4],
+            [1, 0, 4, 5],
             [1, 0, 4, 8, 5],
             [1, 0, 4, 8, 9],
-            [1, 0, 4, 5],
             [1, 0, 4, 9],
             [1, 5, 0, 4],
             [1, 5, 9, 6],

--- a/boggle/boggler_test.py
+++ b/boggle/boggler_test.py
@@ -2,6 +2,7 @@ import functools
 
 import pytest
 from cpp_boggle import Trie
+from inline_snapshot import snapshot
 
 from boggle.boggler import PyBoggler
 from boggle.dimensional_bogglers import cpp_boggler
@@ -68,3 +69,90 @@ def test55(get_trie, Boggler):
     t = get_trie()
     b = Boggler(t, (5, 5))
     assert b.score("sepesdsracietilmanesligdr") == 10406
+
+
+def test_find_words():
+    t = get_cpp_trie()
+    b = cpp_boggler(t, (4, 4))
+    assert (b.find_words("abcdefghijklmnop", False)) == snapshot(
+        [
+            [5, 8, 4],
+            [5, 8, 13],
+            [5, 8, 13, 10],
+            [5, 8, 13, 14],
+            [6, 11, 14, 15],
+            [8, 13, 10],
+            [9, 8, 13],
+            [9, 8, 13, 10],
+            [10, 13, 8, 5, 4],
+            [10, 13, 14, 15],
+            [10, 14, 15],
+            [11, 14, 15],
+            [12, 8, 13, 10],
+            [13, 8, 12],
+            [15, 14, 11],
+            [15, 11, 14, 13, 10],
+        ]
+    )
+
+    three_board = "abc.def.gei....."
+    three_uniq = [path for path in b.find_words(three_board, False) if len(path) > 3]
+    words_uniq = ["".join(three_board[i] for i in path) for path in three_uniq]
+    three_multi = [path for path in b.find_words(three_board, True) if len(path) > 3]
+    words_multi = ["".join(three_board[i] for i in path) for path in three_multi]
+    assert three_uniq == snapshot(
+        [
+            [0, 1, 5, 4],
+            [1, 0, 4, 8, 5],
+            [1, 0, 4, 5],
+            [1, 5, 0, 4],
+            [1, 5, 9, 6],
+            [2, 5, 4, 9],
+            [4, 5, 6, 10],
+            [5, 4, 8, 9],
+            [6, 5, 9, 4],
+            [8, 5, 9, 4],
+        ]
+    )
+    assert words_uniq == snapshot(
+        [
+            "abed",
+            "badge",
+            "bade",
+            "bead",
+            "beef",
+            "cede",
+            "defi",
+            "edge",
+            "feed",
+            "geed",
+        ]
+    )
+    assert three_multi == snapshot(
+        [
+            [0, 1, 5, 4],
+            [1, 0, 4, 8, 5],
+            [1, 0, 4, 8, 9],
+            [1, 0, 4, 5],
+            [1, 0, 4, 9],
+            [1, 5, 0, 4],
+            [1, 5, 9, 6],
+            [2, 5, 4, 9],
+            [4, 5, 6, 10],
+            [4, 9, 6, 10],
+            [5, 4, 8, 9],
+            [6, 5, 9, 4],
+            [6, 9, 5, 4],
+            [8, 5, 9, 4],
+            [8, 9, 5, 4],
+            [9, 4, 8, 5],
+        ]
+    )
+
+    assert set(words_multi) == set(words_uniq)
+
+    b3 = cpp_boggler(t, (3, 3))
+    three_board = "abcdefgei"
+    paths_multi = [path for path in b3.find_words(three_board, True) if len(path) > 3]
+    words_multi3 = ["".join(three_board[i] for i in path) for path in paths_multi]
+    assert sorted(words_multi) == sorted(words_multi3)

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -305,8 +305,8 @@ def main():
     best_score = args.best_score
     assert best_score > 0
     w, h = dims = args.size // 10, args.size % 10
-    assert 3 <= w <= 4
-    assert 3 <= h <= 4
+    assert 3 <= w <= 5
+    assert 3 <= h <= 5
     classes = parse_classes(args.classes, dims)
     assert len(classes) == w * h
     num_classes = [len(c) for c in classes]

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -39,7 +39,6 @@ class BreakDetails:
         d = dataclasses.asdict(self)
         d["elim_level"] = dict(self.elim_level.items())
         d["secs_by_level"] = dict(self.secs_by_level.items())
-        d["depth"] = dict(self.depth.items())
         return d
 
 
@@ -47,7 +46,7 @@ class BreakDetails:
 class HybridBreakDetails(BreakDetails):
     bounds: dict[int, int]
     nodes: dict[int, int]
-    depth: dict[int, int]
+    depth: Counter[int]
     boards_to_test: int
     init_nodes: int
     total_nodes: int
@@ -55,6 +54,11 @@ class HybridBreakDetails(BreakDetails):
     total_bytes: int
     n_bound: int
     n_force: int
+
+    def asdict(self):
+        d = super().asdict()
+        d["depth"] = dict(self.depth.items())
+        return d
 
 
 class HybridTreeBreaker:

--- a/boggle/dimensional_bogglers.py
+++ b/boggle/dimensional_bogglers.py
@@ -3,32 +3,38 @@ from cpp_boggle import (
     Boggler34,
     Boggler44,
     Boggler55,
+    BucketBoggler22,
+    BucketBoggler23,
     BucketBoggler33,
     BucketBoggler34,
     BucketBoggler44,
+    BucketBoggler55,
     OrderlyTreeBuilder22,
+    OrderlyTreeBuilder23,
     OrderlyTreeBuilder33,
     OrderlyTreeBuilder34,
     OrderlyTreeBuilder44,
+    OrderlyTreeBuilder55,
 )
-
-from boggle.ibuckets import PyBucketBoggler22, PyBucketBoggler23
 
 Bogglers = {(3, 3): Boggler33, (3, 4): Boggler34, (4, 4): Boggler44, (5, 5): Boggler55}
 
 BucketBogglers = {
-    (2, 2): PyBucketBoggler22,
-    (2, 3): PyBucketBoggler23,
+    (2, 2): BucketBoggler22,
+    (2, 3): BucketBoggler23,
     (3, 3): BucketBoggler33,
     (3, 4): BucketBoggler34,
     (4, 4): BucketBoggler44,
+    (5, 5): BucketBoggler55,
 }
 
 OrderlyTreeBuilders = {
     (2, 2): OrderlyTreeBuilder22,
+    (2, 3): OrderlyTreeBuilder23,
     (3, 3): OrderlyTreeBuilder33,
     (3, 4): OrderlyTreeBuilder34,
     (4, 4): OrderlyTreeBuilder44,
+    (5, 5): OrderlyTreeBuilder55,
 }
 
 

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -198,7 +198,7 @@ def main():
             for score_board in tops:
                 score, board = score_board
                 freq = best[score_board]
-                print_and_write(f"{score}\t{board}\t{freq}/{args.num_boards}")
+                print_and_write(f"{score}\t{board}\t{freq}/{1+run}")
 
 
 if __name__ == "__main__":

--- a/boggle/hillclimb.py
+++ b/boggle/hillclimb.py
@@ -69,8 +69,14 @@ def get_process_id():
 def hillclimb(task: int):
     me = get_process_id()
     seed = hillclimb.random_seed + task
+
+    def print_and_write(line: str):
+        print(line)
+        with open(f"hillclimb-{me}.txt", "a") as out:
+            out.write(line + "\n")
+
     random.seed(seed)
-    print(f"#{me} starting hillclimb with random seed = {seed}")
+    print_and_write(f"#{me} starting hillclimb with random seed = {seed}")
     args = hillclimb.args
     w, h = hillclimb.dims
     boggler = hillclimb.boggler
@@ -104,7 +110,8 @@ def hillclimb(task: int):
         scores = [(get_score(n), n) for n in ns]
         scores.sort(reverse=True)
         scores = scores[: args.pool_size]
-        print(f"#{me} {num_iter=}: {max(scores)=} {min(scores)=}")
+        line = f"#{me} {num_iter=}: {max(scores)=} {min(scores)=}"
+        print_and_write(line)
         new_pool = [bd for _, bd in scores]
         if new_pool == pool:
             break
@@ -170,21 +177,28 @@ def main():
         hillclimb_init(args)
         it = (hillclimb(task) for task in tasks)
 
+    out = open("hillclimb.root.txt", "w")
+
+    def print_and_write(line: str):
+        print(line)
+        out.write(line)
+        out.write("\n")
+
     best = Counter[tuple[int, str]]()
     for run, (score, board, n, score_boards) in enumerate(it):
-        print(f"{run}/{args.num_boards} {score} {board} ({n} iterations)")
+        print_and_write(f"{run}/{args.num_boards} {score} {board} ({n} iterations)")
         best.update(score_boards)
 
-    if args.num_boards > 1:
-        print("---")
-        print(f"Top {args.pool_size} boards:")
-        tops = [*best.keys()]
-        tops.sort(reverse=True)
-        tops = tops[: args.pool_size]
-        for score_board in tops:
-            score, board = score_board
-            freq = best[score_board]
-            print(f"{score}\t{board}\t{freq}/{args.num_boards}")
+        if args.num_boards > 1:
+            print_and_write("---")
+            print_and_write(f"Top {args.pool_size} boards:")
+            tops = [*best.keys()]
+            tops.sort(reverse=True)
+            tops = tops[: args.pool_size]
+            for score_board in tops:
+                score, board = score_board
+                freq = best[score_board]
+                print_and_write(f"{score}\t{board}\t{freq}/{args.num_boards}")
 
 
 if __name__ == "__main__":

--- a/boggle/neighbors.py
+++ b/boggle/neighbors.py
@@ -40,3 +40,7 @@ NEIGHBORS = {
     (4, 4): NEIGHBORS44,
     (5, 5): NEIGHBORS55,
 }
+
+for i, ns in enumerate(NEIGHBORS[(3, 3)]):
+    csv = ", ".join(str(n) for n in ns)
+    print(f"case {i}: REC{len(ns)}({csv});")

--- a/boggle/neighbors.py
+++ b/boggle/neighbors.py
@@ -41,6 +41,6 @@ NEIGHBORS = {
     (5, 5): NEIGHBORS55,
 }
 
-for i, ns in enumerate(NEIGHBORS[(3, 3)]):
-    csv = ", ".join(str(n) for n in ns)
-    print(f"case {i}: REC{len(ns)}({csv});")
+# for i, ns in enumerate(NEIGHBORS[(3, 3)]):
+#     csv = ", ".join(str(n) for n in ns)
+#     print(f"case {i}: REC{len(ns)}({csv});")

--- a/boggle/neighbors.py
+++ b/boggle/neighbors.py
@@ -40,7 +40,3 @@ NEIGHBORS = {
     (4, 4): NEIGHBORS44,
     (5, 5): NEIGHBORS55,
 }
-
-# for i, ns in enumerate(NEIGHBORS[(3, 3)]):
-#     csv = ", ".join(str(n) for n in ns)
-#     print(f"case {i}: REC{len(ns)}({csv});")

--- a/boggle/perf.py
+++ b/boggle/perf.py
@@ -26,6 +26,11 @@ def main():
         description="Measure the speed of board evaluation, free from I/O.",
     )
     add_standard_args(parser, random_seed=True, python=True)
+    parser.add_argument(
+        "--input_file",
+        type=str,
+        help="Use this file instead of generating random boards.",
+    )
     parser.add_argument("num_boards", type=int, help="Number of boards to evaluate")
     args = parser.parse_args()
     if args.random_seed >= 0:
@@ -35,8 +40,14 @@ def main():
     t, boggler = get_trie_and_boggler_from_args(args)
 
     w, h = args.size // 10, args.size % 10
-    print(f"Generating {n} {w}x{h} boards...")
-    boards = [random_board(w * h) for _ in range(n)]
+    if not args.input_file:
+        print(f"Generating {n} {w}x{h} boards...")
+        boards = [random_board(w * h) for _ in range(n)]
+    else:
+        boards = [line.strip() for line in open(args.input_file)]
+        for board in boards:
+            assert len(board) == w * h
+        print(f"Read {len(boards)} boards from {args.input_file}")
     total_score = 0
     print("Scoring boards...")
     start_s = time.time()

--- a/boggle/ridgeline.py
+++ b/boggle/ridgeline.py
@@ -39,7 +39,7 @@ def make_graph(board1: str, board2: str, scores: dict[str, int]):
         G.add_node(board, score=score)
 
     # Add an edge from each board to the boards an edit distance of 1 away
-    for board in scores.keys():
+    for board in tqdm(scores.keys()):
         for i in diff_indices:
             if board[i] == board1[i]:
                 other = board[:i] + board2[i] + board[i + 1 :]
@@ -55,6 +55,24 @@ def make_graph(board1: str, board2: str, scores: dict[str, int]):
                 raise ValueError(board)
 
     return G
+
+
+def highest_scoring_path(G: nx.Graph, start: str, end: str):
+    """Returns a sequence of nodes in G representing the shortest path from start to end.
+
+    Amongst all shortest paths, this path will have the maximum value for:
+    min(G[node]['score'] for node in path)
+    """
+
+    # Evaluate each path based on the minimum score of its nodes
+    def path_score(path):
+        return min(G.nodes[node]["score"] for node in path)
+
+    # Find all shortest paths from start to end
+    # Select the path with the maximum minimum score
+    best_path = max(nx.all_shortest_paths(G, source=start, target=end), key=path_score)
+
+    return best_path
 
 
 def main():
@@ -82,6 +100,10 @@ def main():
 
     G = make_graph(board1, board2, scores)
     print(f"{G.number_of_nodes()=} {G.number_of_edges()=}")
+
+    path = highest_scoring_path(G, board1, board2)
+    for board in path:
+        print(f"{board}\t{scores[board]}")
 
 
 if __name__ == "__main__":

--- a/boggle/ridgeline.py
+++ b/boggle/ridgeline.py
@@ -1,6 +1,7 @@
 """Find the highest-scoring path between two boards."""
 
 import argparse
+import heapq
 
 import networkx as nx
 from tqdm import tqdm
@@ -64,13 +65,33 @@ def highest_scoring_path(G: nx.Graph, start: str, end: str):
     min(G[node]['score'] for node in path)
     """
 
-    # Evaluate each path based on the minimum score of its nodes
-    def path_score(path):
-        return min(G.nodes[node]["score"] for node in path)
+    # Use a priority queue to find the best path with the maximum minimum score
 
-    # Find all shortest paths from start to end
-    # Select the path with the maximum minimum score
-    best_path = max(nx.all_shortest_paths(G, source=start, target=end), key=path_score)
+    # Priority queue stores (-min_score, current_node, path)
+    pq = [(-G.nodes[start]["score"], start, [start])]
+    visited = set()
+
+    best_path = None
+    best_min_score = float("-inf")
+
+    while pq:
+        neg_min_score, current, path = heapq.heappop(pq)
+        min_score = -neg_min_score
+
+        if current in visited:
+            continue
+        visited.add(current)
+
+        if current == end:
+            if min_score > best_min_score:
+                best_min_score = min_score
+                best_path = path
+            continue
+
+        for neighbor in G.neighbors(current):
+            if neighbor not in visited:
+                new_min_score = min(min_score, G.nodes[neighbor]["score"])
+                heapq.heappush(pq, (-new_min_score, neighbor, path + [neighbor]))
 
     return best_path
 

--- a/boggle/ridgeline.py
+++ b/boggle/ridgeline.py
@@ -3,6 +3,7 @@
 import argparse
 import heapq
 
+import chalk
 import networkx as nx
 from tqdm import tqdm
 
@@ -74,6 +75,7 @@ def highest_scoring_path(G: nx.Graph, start: str, end: str):
     best_path = None
     best_min_score = float("-inf")
 
+    # TODO: does this return the shortest, then highest path? Or just highest?
     while pq:
         neg_min_score, current, path = heapq.heappop(pq)
         min_score = -neg_min_score
@@ -94,6 +96,15 @@ def highest_scoring_path(G: nx.Graph, start: str, end: str):
                 heapq.heappush(pq, (-new_min_score, neighbor, path + [neighbor]))
 
     return best_path
+
+
+YELLOW = chalk.Chalk("yellow") + chalk.utils.FontFormat("bold")
+
+
+def color_diffs(board: str, prev: str | None):
+    if prev is None:
+        return board
+    return "".join(a if a == b else YELLOW(a) for a, b in zip(board, prev))
 
 
 def main():
@@ -123,8 +134,10 @@ def main():
     print(f"{G.number_of_nodes()=} {G.number_of_edges()=}")
 
     path = highest_scoring_path(G, board1, board2)
+    prev = None
     for board in path:
-        print(f"{board}\t{scores[board]}")
+        print(f"{color_diffs(board, prev)}\t{scores[board]}")
+        prev = board
 
 
 if __name__ == "__main__":

--- a/boggle/ridgeline.py
+++ b/boggle/ridgeline.py
@@ -2,8 +2,32 @@
 
 import argparse
 
+from tqdm import tqdm
+
 from boggle.args import add_standard_args, get_trie_and_boggler_from_args
-from boggle.winner_hierarchy import closest, distance, symmetry_group
+from boggle.boggler import PyBoggler
+from boggle.winner_hierarchy import distance, symmetry_group
+
+
+def score_intermediates(boggler: PyBoggler, board1: str, board2: str):
+    # collect inidices of differing letters
+    n = len(board1)
+    diff_indices = [i for i in range(n) if board1[i] != board2[i]]
+    nd = len(diff_indices)
+    print(f"{nd=} {diff_indices=}")
+    bd1list = [*board1]
+
+    scores = {}
+    for i in tqdm(range(0, 2**nd)):
+        bd = [*bd1list]
+        for j in range(nd):
+            if i & (1 << j):
+                dij = diff_indices[j]
+                bd[dij] = board2[dij]
+        bd_str = "".join(bd)
+        scores[bd_str] = boggler.score(bd_str)
+
+    return scores
 
 
 def main():
@@ -25,6 +49,9 @@ def main():
 
     d = distance(board1, board2)
     print(f"d({board1}, {board2}) = {d}")
+
+    scores = score_intermediates(boggler, board1, board2)
+    print(f"Scored {len(scores)} intermediate boards.")
 
 
 if __name__ == "__main__":

--- a/boggle/ridgeline.py
+++ b/boggle/ridgeline.py
@@ -1,0 +1,31 @@
+"""Find the highest-scoring path between two boards."""
+
+import argparse
+
+from boggle.args import add_standard_args, get_trie_and_boggler_from_args
+from boggle.winner_hierarchy import closest, distance, symmetry_group
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="Ridgeline",
+        description="Find the highest-scoring path between two boards",
+    )
+    add_standard_args(parser, random_seed=False, python=True)
+    parser.add_argument("board1", type=str, help="Start board")
+    parser.add_argument("board2", type=str, help="Destination board")
+    args = parser.parse_args()
+    _, boggler = get_trie_and_boggler_from_args(args)
+
+    board1 = args.board1
+    board2 = min(symmetry_group(args.board2), key=lambda b: distance(board1, b))
+
+    if board2 != args.board2:
+        print(f"Rotated {args.board2} -> {board2}")
+
+    d = distance(board1, board2)
+    print(f"d({board1}, {board2}) = {d}")
+
+
+if __name__ == "__main__":
+    main()

--- a/boggle/split_order.py
+++ b/boggle/split_order.py
@@ -52,10 +52,50 @@ SPLIT_ORDER_44 = tuple(
 assert len(SPLIT_ORDER_44) == 16
 assert len(set(SPLIT_ORDER_44)) == 16
 
+
+def to_idx5(x, y):
+    return x * 5 + y
+
+
+SPLIT_ORDER_55 = tuple(
+    to_idx5(x, y)
+    for x, y in (
+        (2, 2),  # super-center
+        (1, 2),
+        (2, 1),
+        (3, 2),
+        (2, 3),  # up/down from center
+        (1, 1),
+        (1, 3),
+        (3, 1),
+        (3, 3),  # diagonal from center
+        (0, 2),
+        (2, 0),
+        (4, 2),
+        (2, 4),  # center sides
+        (1, 0),
+        (3, 0),
+        (0, 1),
+        (0, 3),
+        (1, 4),
+        (3, 4),
+        (4, 1),
+        (4, 3),  # off-center sides
+        (0, 0),
+        (4, 0),
+        (0, 4),
+        (4, 4),  # corners
+    )
+)
+assert len(SPLIT_ORDER_55) == 25
+assert len(set(SPLIT_ORDER_55)) == 25
+
+
 SPLIT_ORDER: dict[tuple[int, int], Sequence[int]] = {
     (2, 2): (0, 1, 2, 3),
     (2, 3): (0, 1, 2, 3, 4, 5),
     (3, 3): SPLIT_ORDER_33,
     (3, 4): SPLIT_ORDER_34,
     (4, 4): SPLIT_ORDER_44,
+    (5, 5): SPLIT_ORDER_55,
 }

--- a/cpp/board_class_boggler.h
+++ b/cpp/board_class_boggler.h
@@ -26,6 +26,7 @@ class BoardClassBoggler {
   // evaluate.
   uint64_t NumReps() const;
 
+  // TODO: move these into a new, standalone header file
   static const int NEIGHBORS[M * N][9];
   static const int SPLIT_ORDER[M * N];
 
@@ -240,6 +241,9 @@ const int BoardClassBoggler<3, 4>::SPLIT_ORDER[3*4] = {5, 6, 1, 9, 2, 10, 4, 7, 
 
 template<>
 const int BoardClassBoggler<4, 4>::SPLIT_ORDER[4*4] = {5, 6, 9, 10, 1, 13, 2, 14, 4, 7, 8, 11, 0, 12, 3, 15};
+
+template<>
+const int BoardClassBoggler<5, 5>::SPLIT_ORDER[5*5] = {12, 7, 11, 17, 13, 6, 8, 16, 18, 2, 10, 22, 14, 5, 15, 1, 3, 9, 19, 21, 23, 0, 20, 4, 24};
 //[[[end]]]
 
 // clang-format on

--- a/cpp/board_class_boggler.h
+++ b/cpp/board_class_boggler.h
@@ -3,6 +3,8 @@
 #ifndef BOARD_CLASS_BOGGLER_H
 #define BOARD_CLASS_BOGGLER_H
 
+#include "trie.h"
+
 // TODO: templating on M, N probably isn't that helpful here, or on any
 // implementations except BucketBoggler.
 template <int M, int N>

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -341,4 +341,4 @@ void Boggler<M, N>::FindWordsDFS(
   seq_.pop_back();
 }
 
-#endif
+#endif  // BOGGLER_4

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -137,7 +137,6 @@ unsigned int Boggler<M, N>::InternalScore() {
 
 #define SUFFIX() used_ ^= (1 << i)
 
-// TODO: codegen specialized bogglers
 // clang-format off
 
 /*[[[cog

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -123,212 +123,43 @@ unsigned int Boggler<M, N>::InternalScore() {
   REC5(a, b, c, d, e);               \
   REC3(f, g, h)
 
+// TODO: this could be an inline method
+#define PREFIX()                  \
+  int c = bd_[i], cc;             \
+  used_ ^= (1 << i);              \
+  len += (c == kQ ? 2 : 1);       \
+  if (t->IsWord()) {              \
+    if (t->Mark() != runs_) {     \
+      t->Mark(runs_);             \
+      score_ += kWordScores[len]; \
+    }                             \
+  }
+
+#define SUFFIX() used_ ^= (1 << i)
+
 // TODO: codegen specialized bogglers
 // clang-format off
 
-// 3x3 Boggle
+/*[[[cog
+from boggle.neighbors import NEIGHBORS
 
-template <>
-void Boggler<3, 3>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
-  int c = bd_[i];
+for (w, h), neighbors in NEIGHBORS.items():
+    print(f"""
+// {w}x{h}
+template<>
+const int Boggler<{w}, {h}>::DoDFS(unsigned int i, unsigned int len, Trie* t) {{
+  PREFIX();
+  switch(i) {{""")
+    for i, ns in enumerate(NEIGHBORS[(3, 3)]):
+        csv = ", ".join(str(n) for n in ns)
+        print(f"    case {i}: REC{len(ns)}({csv});")
 
-  used_ ^= (1 << i);
-  len += (c==kQ ? 2 : 1);
-  if (t->IsWord()) {
-    if (t->Mark() != runs_) {
-      t->Mark(runs_);
-      score_ += kWordScores[len];
-    }
-  }
+    print(f"""  }
+  SUFFIX();
+}""")
+]]]*/
 
-  int cc;
-
-  switch (i) {
-    case 0: REC3(1, 3, 4); break;
-    case 1: REC5(0, 2, 3, 4, 5); break;
-    case 2: REC3(1, 4, 5); break;
-    case 3: REC5(0, 1, 4, 6, 7); break;
-    case 4: REC8(0, 1, 2, 3, 5, 6, 7, 8); break;
-    case 5: REC5(1, 2, 4, 7, 8); break;
-    case 6: REC3(3, 4, 7); break;
-    case 7: REC5(3, 4, 5, 6, 8); break;
-    case 8: REC3(4, 5, 7); break;
-  }
-
-  used_ ^= (1 << i);
-
-}
-
-// 3x4 Boggle
-template <>
-void Boggler<3, 4>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
-  int c = bd_[i];
-
-  used_ ^= (1 << i);
-  len += (c==kQ ? 2 : 1);
-  if (t->IsWord()) {
-    if (t->Mark() != runs_) {
-      t->Mark(runs_);
-      score_ += kWordScores[len];
-    }
-  }
-
-  int cc, idx;
-
-#define HIT(x,y) do { idx = (x) * 4 + y; \
-                      if ((used_ & (1 << idx)) == 0) { \
-                        cc = bd_[idx]; \
-                        if (t->StartsWord(cc)) { \
-                          DoDFS(idx, len, t->Descend(cc)); \
-                        } \
-                      } \
-		 } while(0)
-#define HIT3x(x,y) HIT(x,y); HIT(x+1,y); HIT(x+2,y)
-#define HIT3y(x,y) HIT(x,y); HIT(x,y+1); HIT(x,y+2)
-#define HIT8(x,y) HIT3x(x-1,y-1); HIT(x-1,y); HIT(x+1,y); HIT3x(x-1,y+1)
-
-  // x*4 + y
-  switch (i) {
-    case 0*4 + 0: HIT(0, 1); HIT(1, 0); HIT(1, 1); break;
-    case 0*4 + 1: HIT(0, 0); HIT3y(1, 0); HIT(0, 2); break;
-    case 0*4 + 2: HIT(0, 1); HIT3y(1, 1); HIT(0, 3); break;
-    case 0*4 + 3: HIT(0, 2); HIT(1, 2); HIT(1, 3); break;
-
-    case 1*4 + 0: HIT(0, 0); HIT(2, 0); HIT3x(0, 1); break;
-    case 1*4 + 1: HIT8(1, 1); break;
-    case 1*4 + 2: HIT8(1, 2); break;
-    case 1*4 + 3: HIT3x(0, 2); HIT(0, 3); HIT(2, 3); break;
-
-    case 2*4 + 0: HIT(1, 0); HIT(1, 1); HIT(2, 1); break;
-    case 2*4 + 1: HIT3y(1, 0); HIT(2, 0); HIT(2, 2); break;
-    case 2*4 + 2: HIT3y(1, 1); HIT(2, 1); HIT(2, 3); break;
-    case 2*4 + 3: HIT(1, 3); HIT(1, 2); HIT(2, 2); break;
-  }
-
-  used_ ^= (1 << i);
-
-#undef HIT
-#undef HIT3x
-#undef HIT3y
-#undef HIT8
-}
-
-// 4x4 Boggle
-
-template <>
-void Boggler<4, 4>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
-  int c = bd_[i];
-
-  used_ ^= (1 << i);
-  len += (c==kQ ? 2 : 1);
-  if (t->IsWord()) {
-    if (t->Mark() != runs_) {
-      t->Mark(runs_);
-      score_ += kWordScores[len];
-    }
-  }
-
-  int cc, idx;
-
-#define HIT(x,y) do { idx = (x) * 4 + y; \
-                      if ((used_ & (1 << idx)) == 0) { \
-                        cc = bd_[idx]; \
-                        if (t->StartsWord(cc)) { \
-                          DoDFS(idx, len, t->Descend(cc)); \
-                        } \
-                      } \
-		 } while(0)
-#define HIT3x(x,y) HIT(x,y); HIT(x+1,y); HIT(x+2,y)
-#define HIT3y(x,y) HIT(x,y); HIT(x,y+1); HIT(x,y+2)
-#define HIT8(x,y) HIT3x(x-1,y-1); HIT(x-1,y); HIT(x+1,y); HIT3x(x-1,y+1)
-
-  switch (i) {
-    case 0*4 + 0: HIT(0, 1); HIT(1, 0); HIT(1, 1); break;
-    case 0*4 + 1: HIT(0, 0); HIT3y(1, 0); HIT(0, 2); break;
-    case 0*4 + 2: HIT(0, 1); HIT3y(1, 1); HIT(0, 3); break;
-    case 0*4 + 3: HIT(0, 2); HIT(1, 2); HIT(1, 3); break;
-
-    case 1*4 + 0: HIT(0, 0); HIT(2, 0); HIT3x(0, 1); break;
-    case 1*4 + 1: HIT8(1, 1); break;
-    case 1*4 + 2: HIT8(1, 2); break;
-    case 1*4 + 3: HIT3x(0, 2); HIT(0, 3); HIT(2, 3); break;
-
-    case 2*4 + 0: HIT(1, 0); HIT(3, 0); HIT3x(1, 1); break;
-    case 2*4 + 1: HIT8(2, 1); break;
-    case 2*4 + 2: HIT8(2, 2); break;
-    case 2*4 + 3: HIT3x(1, 2); HIT(1, 3); HIT(3, 3); break;
-
-    case 3*4 + 0: HIT(2, 0); HIT(2, 1); HIT(3, 1); break;
-    case 3*4 + 1: HIT3y(2, 0); HIT(3, 0); HIT(3, 2); break;
-    case 3*4 + 2: HIT3y(2, 1); HIT(3, 1); HIT(3, 3); break;
-    case 3*4 + 3: HIT(2, 2); HIT(3, 2); HIT(2, 3); break;
-  }
-  used_ ^= (1 << i);
-
-#undef HIT
-#undef HIT3x
-#undef HIT3y
-#undef HIT8
-}
-
-// 5x5 Boggle
-
-static int NEIGHBORS55[5*5][9] = {
-  {3, 1, 5, 6},
-  {5, 0, 2, 5, 6, 7},
-  {5, 1, 3, 6, 7, 8},
-  {5, 2, 4, 7, 8, 9},
-  {3, 3, 8, 9},
-  {5, 0, 1, 6, 10, 11},
-  {8, 0, 1, 2, 5, 7, 10, 11, 12},
-  {8, 1, 2, 3, 6, 8, 11, 12, 13},
-  {8, 2, 3, 4, 7, 9, 12, 13, 14},
-  {5, 3, 4, 8, 13, 14},
-  {5, 5, 6, 11, 15, 16},
-  {8, 5, 6, 7, 10, 12, 15, 16, 17},
-  {8, 6, 7, 8, 11, 13, 16, 17, 18},
-  {8, 7, 8, 9, 12, 14, 17, 18, 19},
-  {5, 8, 9, 13, 18, 19},
-  {5, 10, 11, 16, 20, 21},
-  {8, 10, 11, 12, 15, 17, 20, 21, 22},
-  {8, 11, 12, 13, 16, 18, 21, 22, 23},
-  {8, 12, 13, 14, 17, 19, 22, 23, 24},
-  {5, 13, 14, 18, 23, 24},
-  {3, 15, 16, 21},
-  {5, 15, 16, 17, 20, 22},
-  {5, 16, 17, 18, 21, 23},
-  {5, 17, 18, 19, 22, 24},
-  {3, 18, 19, 23},
-};
-
-template <>
-void Boggler<5, 5>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
-  int c = bd_[i];
-
-  used_ ^= (1 << i);
-  len += (c==kQ ? 2 : 1);
-  if (t->IsWord()) {
-    if (t->Mark() != runs_) {
-      t->Mark(runs_);
-      score_ += kWordScores[len];
-    }
-  }
-
-  int* neighbors = NEIGHBORS55[i];
-  int num_neighbors = neighbors[0];
-  for (int j = 1; j <= num_neighbors; j++) {
-    int idx = neighbors[j];
-    if ((used_ & (1 << idx)) == 0) {
-      int cc = bd_[idx];
-      if (t->StartsWord(cc)) {
-        DoDFS(idx, len, t->Descend(cc));
-      }
-    }
-  }
-
-  used_ ^= (1 << i);
-}
-
+// [[[end]]]
 // clang-format on
 
 template <int M, int N>

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -152,7 +152,7 @@ void Boggler<{w}, {h}>::DoDFS(unsigned int i, unsigned int len, Trie* t) {{
   switch(i) {{""")
     for i, ns in enumerate(neighbors):
         csv = ", ".join(str(n) for n in ns)
-        print(f"    case {i}: REC{len(ns)}({csv});")
+        print(f"    case {i}: REC{len(ns)}({csv}); break;")
 
     print("""  }
   SUFFIX();
@@ -164,10 +164,10 @@ template<>
 void Boggler<2, 2>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
   PREFIX();
   switch(i) {
-    case 0: REC3(1, 2, 3);
-    case 1: REC3(0, 2, 3);
-    case 2: REC3(0, 1, 3);
-    case 3: REC3(0, 1, 2);
+    case 0: REC3(1, 2, 3); break;
+    case 1: REC3(0, 2, 3); break;
+    case 2: REC3(0, 1, 3); break;
+    case 3: REC3(0, 1, 2); break;
   }
   SUFFIX();
 }
@@ -177,12 +177,12 @@ template<>
 void Boggler<2, 3>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
   PREFIX();
   switch(i) {
-    case 0: REC3(1, 3, 4);
-    case 1: REC5(0, 2, 3, 4, 5);
-    case 2: REC3(1, 4, 5);
-    case 3: REC3(0, 1, 4);
-    case 4: REC5(0, 1, 2, 3, 5);
-    case 5: REC3(1, 2, 4);
+    case 0: REC3(1, 3, 4); break;
+    case 1: REC5(0, 2, 3, 4, 5); break;
+    case 2: REC3(1, 4, 5); break;
+    case 3: REC3(0, 1, 4); break;
+    case 4: REC5(0, 1, 2, 3, 5); break;
+    case 5: REC3(1, 2, 4); break;
   }
   SUFFIX();
 }
@@ -192,15 +192,15 @@ template<>
 void Boggler<3, 3>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
   PREFIX();
   switch(i) {
-    case 0: REC3(1, 3, 4);
-    case 1: REC5(0, 2, 3, 4, 5);
-    case 2: REC3(1, 4, 5);
-    case 3: REC5(0, 1, 4, 6, 7);
-    case 4: REC8(0, 1, 2, 3, 5, 6, 7, 8);
-    case 5: REC5(1, 2, 4, 7, 8);
-    case 6: REC3(3, 4, 7);
-    case 7: REC5(3, 4, 5, 6, 8);
-    case 8: REC3(4, 5, 7);
+    case 0: REC3(1, 3, 4); break;
+    case 1: REC5(0, 2, 3, 4, 5); break;
+    case 2: REC3(1, 4, 5); break;
+    case 3: REC5(0, 1, 4, 6, 7); break;
+    case 4: REC8(0, 1, 2, 3, 5, 6, 7, 8); break;
+    case 5: REC5(1, 2, 4, 7, 8); break;
+    case 6: REC3(3, 4, 7); break;
+    case 7: REC5(3, 4, 5, 6, 8); break;
+    case 8: REC3(4, 5, 7); break;
   }
   SUFFIX();
 }
@@ -210,18 +210,18 @@ template<>
 void Boggler<3, 4>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
   PREFIX();
   switch(i) {
-    case 0: REC3(1, 4, 5);
-    case 1: REC5(0, 2, 4, 5, 6);
-    case 2: REC5(1, 3, 5, 6, 7);
-    case 3: REC3(2, 6, 7);
-    case 4: REC5(0, 1, 5, 8, 9);
-    case 5: REC8(0, 1, 2, 4, 6, 8, 9, 10);
-    case 6: REC8(1, 2, 3, 5, 7, 9, 10, 11);
-    case 7: REC5(2, 3, 6, 10, 11);
-    case 8: REC3(4, 5, 9);
-    case 9: REC5(4, 5, 6, 8, 10);
-    case 10: REC5(5, 6, 7, 9, 11);
-    case 11: REC3(6, 7, 10);
+    case 0: REC3(1, 4, 5); break;
+    case 1: REC5(0, 2, 4, 5, 6); break;
+    case 2: REC5(1, 3, 5, 6, 7); break;
+    case 3: REC3(2, 6, 7); break;
+    case 4: REC5(0, 1, 5, 8, 9); break;
+    case 5: REC8(0, 1, 2, 4, 6, 8, 9, 10); break;
+    case 6: REC8(1, 2, 3, 5, 7, 9, 10, 11); break;
+    case 7: REC5(2, 3, 6, 10, 11); break;
+    case 8: REC3(4, 5, 9); break;
+    case 9: REC5(4, 5, 6, 8, 10); break;
+    case 10: REC5(5, 6, 7, 9, 11); break;
+    case 11: REC3(6, 7, 10); break;
   }
   SUFFIX();
 }
@@ -231,22 +231,22 @@ template<>
 void Boggler<4, 4>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
   PREFIX();
   switch(i) {
-    case 0: REC3(1, 4, 5);
-    case 1: REC5(0, 2, 4, 5, 6);
-    case 2: REC5(1, 3, 5, 6, 7);
-    case 3: REC3(2, 6, 7);
-    case 4: REC5(0, 1, 5, 8, 9);
-    case 5: REC8(0, 1, 2, 4, 6, 8, 9, 10);
-    case 6: REC8(1, 2, 3, 5, 7, 9, 10, 11);
-    case 7: REC5(2, 3, 6, 10, 11);
-    case 8: REC5(4, 5, 9, 12, 13);
-    case 9: REC8(4, 5, 6, 8, 10, 12, 13, 14);
-    case 10: REC8(5, 6, 7, 9, 11, 13, 14, 15);
-    case 11: REC5(6, 7, 10, 14, 15);
-    case 12: REC3(8, 9, 13);
-    case 13: REC5(8, 9, 10, 12, 14);
-    case 14: REC5(9, 10, 11, 13, 15);
-    case 15: REC3(10, 11, 14);
+    case 0: REC3(1, 4, 5); break;
+    case 1: REC5(0, 2, 4, 5, 6); break;
+    case 2: REC5(1, 3, 5, 6, 7); break;
+    case 3: REC3(2, 6, 7); break;
+    case 4: REC5(0, 1, 5, 8, 9); break;
+    case 5: REC8(0, 1, 2, 4, 6, 8, 9, 10); break;
+    case 6: REC8(1, 2, 3, 5, 7, 9, 10, 11); break;
+    case 7: REC5(2, 3, 6, 10, 11); break;
+    case 8: REC5(4, 5, 9, 12, 13); break;
+    case 9: REC8(4, 5, 6, 8, 10, 12, 13, 14); break;
+    case 10: REC8(5, 6, 7, 9, 11, 13, 14, 15); break;
+    case 11: REC5(6, 7, 10, 14, 15); break;
+    case 12: REC3(8, 9, 13); break;
+    case 13: REC5(8, 9, 10, 12, 14); break;
+    case 14: REC5(9, 10, 11, 13, 15); break;
+    case 15: REC3(10, 11, 14); break;
   }
   SUFFIX();
 }
@@ -256,31 +256,31 @@ template<>
 void Boggler<5, 5>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
   PREFIX();
   switch(i) {
-    case 0: REC3(1, 5, 6);
-    case 1: REC5(0, 2, 5, 6, 7);
-    case 2: REC5(1, 3, 6, 7, 8);
-    case 3: REC5(2, 4, 7, 8, 9);
-    case 4: REC3(3, 8, 9);
-    case 5: REC5(0, 1, 6, 10, 11);
-    case 6: REC8(0, 1, 2, 5, 7, 10, 11, 12);
-    case 7: REC8(1, 2, 3, 6, 8, 11, 12, 13);
-    case 8: REC8(2, 3, 4, 7, 9, 12, 13, 14);
-    case 9: REC5(3, 4, 8, 13, 14);
-    case 10: REC5(5, 6, 11, 15, 16);
-    case 11: REC8(5, 6, 7, 10, 12, 15, 16, 17);
-    case 12: REC8(6, 7, 8, 11, 13, 16, 17, 18);
-    case 13: REC8(7, 8, 9, 12, 14, 17, 18, 19);
-    case 14: REC5(8, 9, 13, 18, 19);
-    case 15: REC5(10, 11, 16, 20, 21);
-    case 16: REC8(10, 11, 12, 15, 17, 20, 21, 22);
-    case 17: REC8(11, 12, 13, 16, 18, 21, 22, 23);
-    case 18: REC8(12, 13, 14, 17, 19, 22, 23, 24);
-    case 19: REC5(13, 14, 18, 23, 24);
-    case 20: REC3(15, 16, 21);
-    case 21: REC5(15, 16, 17, 20, 22);
-    case 22: REC5(16, 17, 18, 21, 23);
-    case 23: REC5(17, 18, 19, 22, 24);
-    case 24: REC3(18, 19, 23);
+    case 0: REC3(1, 5, 6); break;
+    case 1: REC5(0, 2, 5, 6, 7); break;
+    case 2: REC5(1, 3, 6, 7, 8); break;
+    case 3: REC5(2, 4, 7, 8, 9); break;
+    case 4: REC3(3, 8, 9); break;
+    case 5: REC5(0, 1, 6, 10, 11); break;
+    case 6: REC8(0, 1, 2, 5, 7, 10, 11, 12); break;
+    case 7: REC8(1, 2, 3, 6, 8, 11, 12, 13); break;
+    case 8: REC8(2, 3, 4, 7, 9, 12, 13, 14); break;
+    case 9: REC5(3, 4, 8, 13, 14); break;
+    case 10: REC5(5, 6, 11, 15, 16); break;
+    case 11: REC8(5, 6, 7, 10, 12, 15, 16, 17); break;
+    case 12: REC8(6, 7, 8, 11, 13, 16, 17, 18); break;
+    case 13: REC8(7, 8, 9, 12, 14, 17, 18, 19); break;
+    case 14: REC5(8, 9, 13, 18, 19); break;
+    case 15: REC5(10, 11, 16, 20, 21); break;
+    case 16: REC8(10, 11, 12, 15, 17, 20, 21, 22); break;
+    case 17: REC8(11, 12, 13, 16, 18, 21, 22, 23); break;
+    case 18: REC8(12, 13, 14, 17, 19, 22, 23, 24); break;
+    case 19: REC5(13, 14, 18, 23, 24); break;
+    case 20: REC3(15, 16, 21); break;
+    case 21: REC5(15, 16, 17, 20, 22); break;
+    case 22: REC5(16, 17, 18, 21, 23); break;
+    case 23: REC5(17, 18, 19, 22, 24); break;
+    case 24: REC3(18, 19, 23); break;
   }
   SUFFIX();
 }

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -123,7 +123,7 @@ unsigned int Boggler<M, N>::InternalScore() {
   REC5(a, b, c, d, e);               \
   REC3(f, g, h)
 
-// TODO: this could be an inline method
+// PREFIX and SUFFIX could be inline methods instead, but this incurs a ~5% perf hit.
 #define PREFIX()                  \
   int c = bd_[i], cc;             \
   used_ ^= (1 << i);              \

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -288,6 +288,13 @@ void Boggler<5, 5>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
 // [[[end]]]
 // clang-format on
 
+#undef REC
+#undef REC3
+#undef REC5
+#undef REC8
+#undef PREFIX
+#undef SUFFIX
+
 template <int M, int N>
 vector<vector<int>> Boggler<M, N>::FindWords(const string& lets, bool multiboggle) {
   seq_.clear();

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -2,6 +2,7 @@
 #ifndef BOGGLER_4
 #define BOGGLER_4
 
+#include "board_class_boggler.h"
 #include "constants.h"
 #include "trie.h"
 
@@ -19,6 +20,7 @@ class Boggler {
   void SetCell(int x, int y, unsigned int c);
   unsigned int Cell(int x, int y) const;
 
+  // This is used by the web Boggle UI
   vector<vector<int>> FindWords(const string& lets, bool multiboggle);
 
  private:
@@ -307,6 +309,35 @@ vector<vector<int>> Boggler<M, N>::FindWords(const string& lets, bool multiboggl
     }
   }
   return out;
+}
+
+template <int M, int N>
+void Boggler<M, N>::FindWordsDFS(
+    unsigned int i, Trie* t, bool multiboggle, vector<vector<int>>& out
+) {
+  used_ ^= (1 << i);
+  seq_.push_back(i);
+  if (t->IsWord()) {
+    if (t->Mark() != runs_ || multiboggle) {
+      t->Mark(runs_);
+      out.push_back(seq_);
+    }
+  }
+
+  auto& neighbors = BoardClassBoggler<M, N>::NEIGHBORS[i];
+  auto n_neighbors = neighbors[0];
+  for (int j = 1; j <= n_neighbors; j++) {
+    auto idx = neighbors[j];
+    if ((used_ & (1 << idx)) == 0) {
+      int cc = bd_[idx];
+      if (cc != -1 && t->StartsWord(cc)) {
+        FindWordsDFS(idx, t->Descend(cc), multiboggle, out);
+      }
+    }
+  }
+
+  used_ ^= (1 << i);
+  seq_.pop_back();
 }
 
 // TODO: make this generic on M, N via BoardClassBoggler<M, N>::NEIGHBORS

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -144,18 +144,19 @@ void Boggler<3, 3>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
   int cc;
 
   switch (i) {
-    case 0: REC3(1, 3, 4);
-    case 1: REC5(0, 2, 3, 4, 5);
-    case 2: REC3(1, 4, 5);
-    case 3: REC5(0, 1, 4, 6, 7);
-    case 4: REC8(0, 1, 2, 3, 5, 6, 7, 8);
-    case 5: REC5(1, 2, 4, 7, 8);
-    case 6: REC3(3, 4, 7);
-    case 7: REC5(3, 4, 5, 6, 8);
-    case 8: REC3(4, 5, 7);
+    case 0: REC3(1, 3, 4); break;
+    case 1: REC5(0, 2, 3, 4, 5); break;
+    case 2: REC3(1, 4, 5); break;
+    case 3: REC5(0, 1, 4, 6, 7); break;
+    case 4: REC8(0, 1, 2, 3, 5, 6, 7, 8); break;
+    case 5: REC5(1, 2, 4, 7, 8); break;
+    case 6: REC3(3, 4, 7); break;
+    case 7: REC5(3, 4, 5, 6, 8); break;
+    case 8: REC3(4, 5, 7); break;
   }
 
   used_ ^= (1 << i);
+
 }
 
 // 3x4 Boggle

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -311,6 +311,7 @@ vector<vector<int>> Boggler<M, N>::FindWords(const string& lets, bool multiboggl
   return out;
 }
 
+// This could be specialized, but it's not as performance-sensitive as DoDFS()
 template <int M, int N>
 void Boggler<M, N>::FindWordsDFS(
     unsigned int i, Trie* t, bool multiboggle, vector<vector<int>>& out
@@ -336,66 +337,6 @@ void Boggler<M, N>::FindWordsDFS(
     }
   }
 
-  used_ ^= (1 << i);
-  seq_.pop_back();
-}
-
-// TODO: make this generic on M, N via BoardClassBoggler<M, N>::NEIGHBORS
-template <>
-void Boggler<4, 4>::FindWordsDFS(
-    unsigned int i, Trie* t, bool multiboggle, vector<vector<int>>& out
-) {
-  used_ ^= (1 << i);
-  seq_.push_back(i);
-  if (t->IsWord()) {
-    if (t->Mark() != runs_ || multiboggle) {
-      t->Mark(runs_);
-      out.push_back(seq_);
-    }
-  }
-
-  int cc, idx;
-
-  // clang-format off
-#define HIT(x,y) do { idx = (x) * 4 + y; \
-  if ((used_ & (1 << idx)) == 0) { \
-    cc = bd_[idx]; \
-    if (cc != -1 && t->StartsWord(cc)) { \
-      FindWordsDFS(idx, t->Descend(cc), multiboggle, out); \
-    } \
-  } \
-} while(0)
-#define HIT3x(x,y) HIT(x,y); HIT(x+1,y); HIT(x+2,y)
-#define HIT3y(x,y) HIT(x,y); HIT(x,y+1); HIT(x,y+2)
-#define HIT8(x,y) HIT3x(x-1,y-1); HIT(x-1,y); HIT(x+1,y); HIT3x(x-1,y+1)
-
-  switch (i) {
-    case 0*4 + 0: HIT(0, 1); HIT(1, 0); HIT(1, 1); break;
-    case 0*4 + 1: HIT(0, 0); HIT3y(1, 0); HIT(0, 2); break;
-    case 0*4 + 2: HIT(0, 1); HIT3y(1, 1); HIT(0, 3); break;
-    case 0*4 + 3: HIT(0, 2); HIT(1, 2); HIT(1, 3); break;
-
-    case 1*4 + 0: HIT(0, 0); HIT(2, 0); HIT3x(0, 1); break;
-    case 1*4 + 1: HIT8(1, 1); break;
-    case 1*4 + 2: HIT8(1, 2); break;
-    case 1*4 + 3: HIT3x(0, 2); HIT(0, 3); HIT(2, 3); break;
-
-    case 2*4 + 0: HIT(1, 0); HIT(3, 0); HIT3x(1, 1); break;
-    case 2*4 + 1: HIT8(2, 1); break;
-    case 2*4 + 2: HIT8(2, 2); break;
-    case 2*4 + 3: HIT3x(1, 2); HIT(1, 3); HIT(3, 3); break;
-
-    case 3*4 + 0: HIT(2, 0); HIT(2, 1); HIT(3, 1); break;
-    case 3*4 + 1: HIT3y(2, 0); HIT(3, 0); HIT(3, 2); break;
-    case 3*4 + 2: HIT3y(2, 1); HIT(3, 1); HIT(3, 3); break;
-    case 3*4 + 3: HIT(2, 2); HIT(3, 2); HIT(2, 3); break;
-  }
-
-#undef HIT
-#undef HIT3x
-#undef HIT3y
-#undef HIT8
-  // clang-format on
   used_ ^= (1 << i);
   seq_.pop_back();
 }

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -147,18 +147,143 @@ for (w, h), neighbors in NEIGHBORS.items():
     print(f"""
 // {w}x{h}
 template<>
-const int Boggler<{w}, {h}>::DoDFS(unsigned int i, unsigned int len, Trie* t) {{
+void Boggler<{w}, {h}>::DoDFS(unsigned int i, unsigned int len, Trie* t) {{
   PREFIX();
   switch(i) {{""")
-    for i, ns in enumerate(NEIGHBORS[(3, 3)]):
+    for i, ns in enumerate(neighbors):
         csv = ", ".join(str(n) for n in ns)
         print(f"    case {i}: REC{len(ns)}({csv});")
 
-    print(f"""  }
+    print("""  }
   SUFFIX();
 }""")
 ]]]*/
 
+// 2x2
+template<>
+void Boggler<2, 2>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
+  PREFIX();
+  switch(i) {
+    case 0: REC3(1, 2, 3);
+    case 1: REC3(0, 2, 3);
+    case 2: REC3(0, 1, 3);
+    case 3: REC3(0, 1, 2);
+  }
+  SUFFIX();
+}
+
+// 2x3
+template<>
+void Boggler<2, 3>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
+  PREFIX();
+  switch(i) {
+    case 0: REC3(1, 3, 4);
+    case 1: REC5(0, 2, 3, 4, 5);
+    case 2: REC3(1, 4, 5);
+    case 3: REC3(0, 1, 4);
+    case 4: REC5(0, 1, 2, 3, 5);
+    case 5: REC3(1, 2, 4);
+  }
+  SUFFIX();
+}
+
+// 3x3
+template<>
+void Boggler<3, 3>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
+  PREFIX();
+  switch(i) {
+    case 0: REC3(1, 3, 4);
+    case 1: REC5(0, 2, 3, 4, 5);
+    case 2: REC3(1, 4, 5);
+    case 3: REC5(0, 1, 4, 6, 7);
+    case 4: REC8(0, 1, 2, 3, 5, 6, 7, 8);
+    case 5: REC5(1, 2, 4, 7, 8);
+    case 6: REC3(3, 4, 7);
+    case 7: REC5(3, 4, 5, 6, 8);
+    case 8: REC3(4, 5, 7);
+  }
+  SUFFIX();
+}
+
+// 3x4
+template<>
+void Boggler<3, 4>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
+  PREFIX();
+  switch(i) {
+    case 0: REC3(1, 4, 5);
+    case 1: REC5(0, 2, 4, 5, 6);
+    case 2: REC5(1, 3, 5, 6, 7);
+    case 3: REC3(2, 6, 7);
+    case 4: REC5(0, 1, 5, 8, 9);
+    case 5: REC8(0, 1, 2, 4, 6, 8, 9, 10);
+    case 6: REC8(1, 2, 3, 5, 7, 9, 10, 11);
+    case 7: REC5(2, 3, 6, 10, 11);
+    case 8: REC3(4, 5, 9);
+    case 9: REC5(4, 5, 6, 8, 10);
+    case 10: REC5(5, 6, 7, 9, 11);
+    case 11: REC3(6, 7, 10);
+  }
+  SUFFIX();
+}
+
+// 4x4
+template<>
+void Boggler<4, 4>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
+  PREFIX();
+  switch(i) {
+    case 0: REC3(1, 4, 5);
+    case 1: REC5(0, 2, 4, 5, 6);
+    case 2: REC5(1, 3, 5, 6, 7);
+    case 3: REC3(2, 6, 7);
+    case 4: REC5(0, 1, 5, 8, 9);
+    case 5: REC8(0, 1, 2, 4, 6, 8, 9, 10);
+    case 6: REC8(1, 2, 3, 5, 7, 9, 10, 11);
+    case 7: REC5(2, 3, 6, 10, 11);
+    case 8: REC5(4, 5, 9, 12, 13);
+    case 9: REC8(4, 5, 6, 8, 10, 12, 13, 14);
+    case 10: REC8(5, 6, 7, 9, 11, 13, 14, 15);
+    case 11: REC5(6, 7, 10, 14, 15);
+    case 12: REC3(8, 9, 13);
+    case 13: REC5(8, 9, 10, 12, 14);
+    case 14: REC5(9, 10, 11, 13, 15);
+    case 15: REC3(10, 11, 14);
+  }
+  SUFFIX();
+}
+
+// 5x5
+template<>
+void Boggler<5, 5>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
+  PREFIX();
+  switch(i) {
+    case 0: REC3(1, 5, 6);
+    case 1: REC5(0, 2, 5, 6, 7);
+    case 2: REC5(1, 3, 6, 7, 8);
+    case 3: REC5(2, 4, 7, 8, 9);
+    case 4: REC3(3, 8, 9);
+    case 5: REC5(0, 1, 6, 10, 11);
+    case 6: REC8(0, 1, 2, 5, 7, 10, 11, 12);
+    case 7: REC8(1, 2, 3, 6, 8, 11, 12, 13);
+    case 8: REC8(2, 3, 4, 7, 9, 12, 13, 14);
+    case 9: REC5(3, 4, 8, 13, 14);
+    case 10: REC5(5, 6, 11, 15, 16);
+    case 11: REC8(5, 6, 7, 10, 12, 15, 16, 17);
+    case 12: REC8(6, 7, 8, 11, 13, 16, 17, 18);
+    case 13: REC8(7, 8, 9, 12, 14, 17, 18, 19);
+    case 14: REC5(8, 9, 13, 18, 19);
+    case 15: REC5(10, 11, 16, 20, 21);
+    case 16: REC8(10, 11, 12, 15, 17, 20, 21, 22);
+    case 17: REC8(11, 12, 13, 16, 18, 21, 22, 23);
+    case 18: REC8(12, 13, 14, 17, 19, 22, 23, 24);
+    case 19: REC5(13, 14, 18, 23, 24);
+    case 20: REC3(15, 16, 21);
+    case 21: REC5(15, 16, 17, 20, 22);
+    case 22: REC5(16, 17, 18, 21, 23);
+    case 23: REC5(17, 18, 19, 22, 24);
+    case 24: REC3(18, 19, 23);
+  }
+  SUFFIX();
+}
 // [[[end]]]
 // clang-format on
 
@@ -185,6 +310,7 @@ vector<vector<int>> Boggler<M, N>::FindWords(const string& lets, bool multiboggl
   return out;
 }
 
+// TODO: make this generic on M, N via BoardClassBoggler<M, N>::NEIGHBORS
 template <>
 void Boggler<4, 4>::FindWordsDFS(
     unsigned int i, Trie* t, bool multiboggle, vector<vector<int>>& out

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -99,6 +99,30 @@ unsigned int Boggler<M, N>::InternalScore() {
   return score_;
 }
 
+#define REC(idx)                         \
+  do {                                   \
+    if ((used_ & (1 << idx)) == 0) {     \
+      cc = bd_[idx];                     \
+      if (t->StartsWord(cc)) {           \
+        DoDFS(idx, len, t->Descend(cc)); \
+      }                                  \
+    }                                    \
+  } while (0)
+
+#define REC3(a, b, c) \
+  REC(a);             \
+  REC(b);             \
+  REC(c)
+
+#define REC5(a, b, c, d, e) \
+  REC3(a, b, c);            \
+  REC(d);                   \
+  REC(e)
+
+#define REC8(a, b, c, d, e, f, g, h) \
+  REC5(a, b, c, d, e);               \
+  REC3(f, g, h)
+
 // TODO: codegen specialized bogglers
 // clang-format off
 
@@ -117,41 +141,21 @@ void Boggler<3, 3>::DoDFS(unsigned int i, unsigned int len, Trie* t) {
     }
   }
 
-  int cc, idx;
+  int cc;
 
-#define HIT(x,y) do { idx = (x) * 3 + y; \
-                      if ((used_ & (1 << idx)) == 0) { \
-                        cc = bd_[idx]; \
-                        if (t->StartsWord(cc)) { \
-                          DoDFS(idx, len, t->Descend(cc)); \
-                        } \
-                      } \
-		 } while(0)
-#define HIT3x(x,y) HIT(x,y); HIT(x+1,y); HIT(x+2,y)
-#define HIT3y(x,y) HIT(x,y); HIT(x,y+1); HIT(x,y+2)
-#define HIT8(x,y) HIT3x(x-1,y-1); HIT(x-1,y); HIT(x+1,y); HIT3x(x-1,y+1)
-
-  // x*3 + y
   switch (i) {
-    case 0*3 + 0: HIT(0, 1); HIT(1, 0); HIT(1, 1); break;
-    case 0*3 + 1: HIT(0, 0); HIT3y(1, 0); HIT(0, 2); break;
-    case 0*3 + 2: HIT(0, 1); HIT(1, 1); HIT(1, 2); break;
-
-    case 1*3 + 0: HIT(0, 0); HIT(2, 0); HIT3x(0, 1); break;
-    case 1*3 + 1: HIT8(1, 1); break;
-    case 1*3 + 2: HIT3x(0, 1); HIT(0, 2); HIT(2, 2); break;
-
-    case 2*3 + 0: HIT(1, 0); HIT(1, 1); HIT(2, 1); break;
-    case 2*3 + 1: HIT3y(1, 0); HIT(2, 0); HIT(2, 2); break;
-    case 2*3 + 2: HIT(1, 2); HIT(1, 1); HIT(2, 1); break;
+    case 0: REC3(1, 3, 4);
+    case 1: REC5(0, 2, 3, 4, 5);
+    case 2: REC3(1, 4, 5);
+    case 3: REC5(0, 1, 4, 6, 7);
+    case 4: REC8(0, 1, 2, 3, 5, 6, 7, 8);
+    case 5: REC5(1, 2, 4, 7, 8);
+    case 6: REC3(3, 4, 7);
+    case 7: REC5(3, 4, 5, 6, 8);
+    case 8: REC3(4, 5, 7);
   }
 
   used_ ^= (1 << i);
-
-#undef HIT
-#undef HIT3x
-#undef HIT3y
-#undef HIT8
 }
 
 // 3x4 Boggle

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -83,19 +83,26 @@ PYBIND11_MODULE(cpp_boggle, m) {
       )
       .def_static("CreateFromFile", &Trie::CreateFromFile);
 
+  declare_boggler<2, 2>(m, "Boggler22");
+  declare_boggler<2, 3>(m, "Boggler23");
   declare_boggler<3, 3>(m, "Boggler33");
   declare_boggler<3, 4>(m, "Boggler34");
   declare_boggler<4, 4>(m, "Boggler44");
   declare_boggler<5, 5>(m, "Boggler55");
 
+  declare_bucket_boggler<2, 2>(m, "BucketBoggler22");
+  declare_bucket_boggler<2, 3>(m, "BucketBoggler23");
   declare_bucket_boggler<3, 3>(m, "BucketBoggler33");
   declare_bucket_boggler<3, 4>(m, "BucketBoggler34");
   declare_bucket_boggler<4, 4>(m, "BucketBoggler44");
+  declare_bucket_boggler<5, 5>(m, "BucketBoggler55");
 
   declare_tree_builder<OrderlyTreeBuilder<2, 2>>(m, "OrderlyTreeBuilder22");
+  declare_tree_builder<OrderlyTreeBuilder<2, 3>>(m, "OrderlyTreeBuilder23");
   declare_tree_builder<OrderlyTreeBuilder<3, 3>>(m, "OrderlyTreeBuilder33");
   declare_tree_builder<OrderlyTreeBuilder<3, 4>>(m, "OrderlyTreeBuilder34");
   declare_tree_builder<OrderlyTreeBuilder<4, 4>>(m, "OrderlyTreeBuilder44");
+  declare_tree_builder<OrderlyTreeBuilder<5, 5>>(m, "OrderlyTreeBuilder55");
 
   py::class_<ScoreDetails>(m, "ScoreDetails", py::buffer_protocol())
       .def_readwrite("max_nomark", &ScoreDetails::max_nomark)

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -54,6 +54,7 @@ void declare_boggler(py::module &m, const string &pyclass_name) {
   py::class_<BB>(m, pyclass_name.c_str(), py::buffer_protocol())
       .def(py::init<Trie *>())
       .def("score", &BB::Score)
+      .def("find_words", &BB::FindWords)
       .def("cell", &BB::Cell)
       .def("set_cell", &BB::SetCell);
 }

--- a/cpp/ibuckets.h
+++ b/cpp/ibuckets.h
@@ -47,6 +47,7 @@ class BucketBoggler : public BoardClassBoggler<M, N> {
   ScoreDetails details_;
   unsigned int DoAllDescents(unsigned int idx, unsigned int len, Trie* t);
   unsigned int DoDFS(unsigned int i, unsigned int len, Trie* t);
+  unsigned int ExitDFS(unsigned int i, unsigned int len, Trie* t);
 };
 
 template <int M, int N>
@@ -94,6 +95,30 @@ unsigned int BucketBoggler<M, N>::DoDFS(unsigned int i, unsigned int len, Trie* 
   exit(1);
 }
 
+template <int M, int N>
+unsigned int BucketBoggler<M, N>::ExitDFS(unsigned int i, unsigned int len, Trie* t) {
+  unsigned int score = 0;
+  if (t->IsWord()) {
+    unsigned int word_score = kWordScores[len];
+    score += word_score;
+    if (PrintWords)
+      printf(
+          " +%2d (%d,%d) %s\n",
+          word_score,
+          i / 3,
+          i % 3,
+          Trie::ReverseLookup(dict_, t).c_str()
+      );
+
+    if (t->Mark() != runs_) {
+      details_.sum_union += word_score;
+      t->Mark(runs_);
+    }
+  }
+  used_ ^= (1 << i);
+  return score;
+}
+
 // TODO: codegen specialized bogglers
 // clang-format off
 
@@ -135,20 +160,7 @@ unsigned int BucketBoggler<3, 3>::DoDFS(unsigned int i, unsigned int len, Trie* 
 #undef HIT3y
 #undef HIT8
 
-  if (t->IsWord()) {
-    unsigned int word_score = kWordScores[len];
-    score += word_score;
-    if (PrintWords)
-      printf(" +%2d (%d,%d) %s\n", word_score, i/3, i%3,
-            Trie::ReverseLookup(dict_, t).c_str());
-
-    if (t->Mark() != runs_) {
-      details_.sum_union += word_score;
-      t->Mark(runs_);
-    }
-  }
-
-  used_ ^= (1 << i);
+  score += ExitDFS(i, len, t);
   return score;
 }
 
@@ -193,20 +205,7 @@ unsigned int BucketBoggler<3, 4>::DoDFS(unsigned int i, unsigned int len, Trie* 
 #undef HIT3y
 #undef HIT8
 
-  if (t->IsWord()) {
-    unsigned int word_score = kWordScores[len];
-    score += word_score;
-    if (PrintWords)
-      printf(" +%2d (%d,%d) %s\n", word_score, i/4, i%4,
-            Trie::ReverseLookup(dict_, t).c_str());
-
-    if (t->Mark() != runs_) {
-      details_.sum_union += word_score;
-      t->Mark(runs_);
-    }
-  }
-
-  used_ ^= (1 << i);
+  score += ExitDFS(i, len, t);
   return score;
 }
 
@@ -253,20 +252,7 @@ unsigned int BucketBoggler<4, 4>::DoDFS(unsigned int i, unsigned int len, Trie* 
 #undef HIT3y
 #undef HIT8
 
-  if (t->IsWord()) {
-    unsigned int word_score = kWordScores[len];
-    score += word_score;
-    if (PrintWords)
-      printf(" +%2d (%d,%d) %s\n", word_score, i/4, i%4,
-            Trie::ReverseLookup(dict_, t).c_str());
-
-    if (t->Mark() != runs_) {
-      details_.sum_union += word_score;
-      t->Mark(runs_);
-    }
-  }
-
-  used_ ^= (1 << i);
+  score += ExitDFS(i, len, t);
   return score;
 }
 

--- a/cpp/ibuckets.h
+++ b/cpp/ibuckets.h
@@ -47,7 +47,7 @@ class BucketBoggler : public BoardClassBoggler<M, N> {
   ScoreDetails details_;
   unsigned int DoAllDescents(unsigned int idx, unsigned int len, Trie* t);
   unsigned int DoDFS(unsigned int i, unsigned int len, Trie* t);
-  unsigned int ExitDFS(unsigned int i, unsigned int len, Trie* t);
+  unsigned int CountWord(unsigned int i, unsigned int len, Trie* t);
 };
 
 template <int M, int N>
@@ -96,7 +96,7 @@ unsigned int BucketBoggler<M, N>::DoDFS(unsigned int i, unsigned int len, Trie* 
 }
 
 template <int M, int N>
-unsigned int BucketBoggler<M, N>::ExitDFS(unsigned int i, unsigned int len, Trie* t) {
+unsigned int BucketBoggler<M, N>::CountWord(unsigned int i, unsigned int len, Trie* t) {
   unsigned int score = 0;
   if (t->IsWord()) {
     unsigned int word_score = kWordScores[len];
@@ -115,7 +115,6 @@ unsigned int BucketBoggler<M, N>::ExitDFS(unsigned int i, unsigned int len, Trie
       t->Mark(runs_);
     }
   }
-  used_ ^= (1 << i);
   return score;
 }
 
@@ -158,7 +157,8 @@ unsigned int BucketBoggler<{w}, {h}>::DoDFS(unsigned int i, unsigned int len, Tr
         print(f"    case {i}: REC{len(ns)}({csv}); break;")
 
     print("""  }
-  score += ExitDFS(i, len, t);
+  score += CountWord(i, len, t);
+  used_ ^= (1 << i);
   return score;
 }""")
 ]]]*/
@@ -174,7 +174,8 @@ unsigned int BucketBoggler<2, 2>::DoDFS(unsigned int i, unsigned int len, Trie* 
     case 2: REC3(0, 1, 3); break;
     case 3: REC3(0, 1, 2); break;
   }
-  score += ExitDFS(i, len, t);
+  score += CountWord(i, len, t);
+  used_ ^= (1 << i);
   return score;
 }
 
@@ -191,7 +192,8 @@ unsigned int BucketBoggler<2, 3>::DoDFS(unsigned int i, unsigned int len, Trie* 
     case 4: REC5(0, 1, 2, 3, 5); break;
     case 5: REC3(1, 2, 4); break;
   }
-  score += ExitDFS(i, len, t);
+  score += CountWord(i, len, t);
+  used_ ^= (1 << i);
   return score;
 }
 
@@ -211,7 +213,8 @@ unsigned int BucketBoggler<3, 3>::DoDFS(unsigned int i, unsigned int len, Trie* 
     case 7: REC5(3, 4, 5, 6, 8); break;
     case 8: REC3(4, 5, 7); break;
   }
-  score += ExitDFS(i, len, t);
+  score += CountWord(i, len, t);
+  used_ ^= (1 << i);
   return score;
 }
 
@@ -234,7 +237,8 @@ unsigned int BucketBoggler<3, 4>::DoDFS(unsigned int i, unsigned int len, Trie* 
     case 10: REC5(5, 6, 7, 9, 11); break;
     case 11: REC3(6, 7, 10); break;
   }
-  score += ExitDFS(i, len, t);
+  score += CountWord(i, len, t);
+  used_ ^= (1 << i);
   return score;
 }
 
@@ -261,7 +265,8 @@ unsigned int BucketBoggler<4, 4>::DoDFS(unsigned int i, unsigned int len, Trie* 
     case 14: REC5(9, 10, 11, 13, 15); break;
     case 15: REC3(10, 11, 14); break;
   }
-  score += ExitDFS(i, len, t);
+  score += CountWord(i, len, t);
+  used_ ^= (1 << i);
   return score;
 }
 
@@ -297,7 +302,8 @@ unsigned int BucketBoggler<5, 5>::DoDFS(unsigned int i, unsigned int len, Trie* 
     case 23: REC5(17, 18, 19, 22, 24); break;
     case 24: REC3(18, 19, 23); break;
   }
-  score += ExitDFS(i, len, t);
+  score += CountWord(i, len, t);
+  used_ ^= (1 << i);
   return score;
 }
 // [[[end]]]

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -126,17 +126,8 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
           return cell_to_order_[a.first] < cell_to_order_[b.first];
         }
     );
-    /*
-    cout << "AddWord:";
-    for (int j = 0; j < n; j++) {
-      auto [cell, letter] = orderly_choices_[j];
-      cout << " (" << cell << "=" << letter << "):" << bd_[cell][letter];
-    }
-    cout << endl;
-    */
     auto new_root =
         root_->AddWordWork(n, orderly_choices_, num_letters_.data(), word_score, arena);
-    // cout << "/AddWord" << endl;
     assert(new_root == root_);
   }
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -614,6 +614,19 @@ files = [
 global = ["pybind11-global (==2.13.6)"]
 
 [[package]]
+name = "pychalk"
+version = "2.0.1"
+description = "Color printing in python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pychalk-2.0.1.tar.gz", hash = "sha256:f763275f6fa68835a30d22c2449f73724d569f33532a031d26e32edc604e7e39"},
+]
+
+[package.dependencies]
+six = ">=1.11.0"
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -728,6 +741,17 @@ files = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
@@ -768,4 +792,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.13"
-content-hash = "1d79f5804fb632c6440354ba47b9b6574380999eb79f1c1d48830900a76a060c"
+content-hash = "d3d9ed8fb25af2ec05a28f8261aef4f57247908d4f0d4151286878dce7a6870a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -429,6 +429,25 @@ files = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.4.2"
+description = "Python package for creating and manipulating graphs and networks"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f"},
+    {file = "networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1"},
+]
+
+[package.extras]
+default = ["matplotlib (>=3.7)", "numpy (>=1.24)", "pandas (>=2.0)", "scipy (>=1.10,!=1.11.0,!=1.11.1)"]
+developer = ["changelist (==0.5)", "mypy (>=1.1)", "pre-commit (>=3.2)", "rtoml"]
+doc = ["intersphinx-registry", "myst-nb (>=1.1)", "numpydoc (>=1.8.0)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.15)", "sphinx (>=7.3)", "sphinx-gallery (>=0.16)", "texext (>=0.6.7)"]
+example = ["cairocffi (>=1.7)", "contextily (>=1.6)", "igraph (>=0.11)", "momepy (>=0.7.2)", "osmnx (>=1.9)", "scikit-learn (>=1.5)", "seaborn (>=0.13)"]
+extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.10)"]
+test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
+
+[[package]]
 name = "numpy"
 version = "2.2.1"
 description = "Fundamental package for array computing in Python"
@@ -749,4 +768,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.13"
-content-hash = "4ca9d062f1295ec878a58df542d21f4ebfb9a2a835e2409befc39861ccc250ee"
+content-hash = "1d79f5804fb632c6440354ba47b9b6574380999eb79f1c1d48830900a76a060c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ gprof2dot = "^2024.6.6"
 numpy = "^2.2.1"
 google-cloud-storage = "^3.1.0"
 networkx = "^3.4.2"
+pychalk = "^2.0.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ ruff = "^0.8.4"
 gprof2dot = "^2024.6.6"
 numpy = "^2.2.1"
 google-cloud-storage = "^3.1.0"
+networkx = "^3.4.2"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- Replace the [17 year old `HIT` macros](https://github.com/danvk/performance-boggle/commit/50ff64ada9be8436c1d96f362e1d040837d06d21) with something that isn't board size-dependent and is cleaner to codegen with Cog. Fixes #99
- Move the 5x5 Boggle solver over to the macro system (previously it used a for loop). This is a big speedup, especially on hard boards:
  - Random boards: 81258.72 → 99008.81 bds/sec (+22%)
  - Good boards w/ JPA14: 8048.78 → 13873.53 bds/sec (+72%)
  - Good boards w/ TWL06: 7332.70 → 12500.57 bds/sec (+70%)
  - This means my not-very-clever Trie structure is ~70% faster than JohnPaul Adamovsky's [GunsOfNavarone.c](https://pages.pathcom.com/~vadco/guns.html)
  - This makes 5x5 hill climbing go _much_ faster.
- Improve logging for multithreaded hillclimbing, eliminating the need to `tee` it into a file.
- Add support for 5x5 to ibuckets, orderly_tree_builder and break_all
  - These board classes can be… tough. The bounds for ibuckets can even overflow 32-bit integers.
  - Orderly bounds do OK.
  - best board class w/ four buckets
    - orderly: t.bound=5473460, 145158348 nodes, 14.5s and ~3GB of RAM
    - ibuckets: max=2037881370, sum=overflow, 0.11s, ~100MB of RAM
  - abcdefghijklmnopqrstuvwxy w/ three buckets
    - orderly: t.bound=11073, 838401 nodes, 0.08s, ~120MB RAM
    - ibuckets: max=53794, sum=160166, 0.03s, ~100MB RAM
  - breaking the best board's class with four buckets seemed like it would take an eternity.
  - breaking a lousy board's class with three buckets went pretty fast.
  - breaking the best board's class with five buckets is on pace for 4-5 hours.
  - This gives me a very hand-wavy estimate of ~10s / board class with five buckets → ~12B CPU years (!)
- Update `README.md` with corrected and canonicalized 5x5 hill climbing winners. ENABLE2K and TWL06 do not have the same best board.
- Expose `FindWords` via `cpp_boggle` and test it (this is what https://github.com/danvk/webboggle uses)
- Add  "ridgeline" script
  - This computes the shortest path between two boards with the highest minimum score.
  - This gives some indication of how hard it is to get from one peak to another via hillclimbing.

Example ridge line path for two of the top three boards for ENABLE2K (21 steps -- too long!):

```
rdgassentmliteicarsdseper	10390
rsgassentmliteicarsdseper	10142
rsgaspentmliteicarsdseper	10350
rsdaspentmliteicarsdseper	9871
rsdespentmliteicarsdseper	8934
rsdespentmlitaicarsdseper	8783
rsdespenimlitaicarsdseper	8539
rsdespenimlitalcarsdseper	8645
rsdespenimlitalcarspseper	8550
rsdespenimlitalcarspseped	8676
rsdespenimlitalcarspseted	9494
rsdespeniclitalcarspseted	9140
rsdespeniclitalcarspgeted	8868
rsdespeniclitalnarspgeted	9588
rsdespeniclitalnarspgeped	8704
rsdespenicmitalnarspgeped	9195
rsdespenicmitalnarspgeted	10109
rsdaspenicmitalnarspgeted	9102
rsdaspenicmitalnarspgsted	8660
rsdespenicmitalnarspgsted	9680
rsdespenicmitalnarepgsted	9141
rsdespenicmitalnarepgstsd	10379
```