### PR TITLE
Fix 5x5 score evaluation for long words

### DIFF
--- a/boggle/boggler.py
+++ b/boggle/boggler.py
@@ -1,7 +1,7 @@
 from boggle.neighbors import NEIGHBORS
 from boggle.trie import make_lookup_table
-
-SCORES = (0, 0, 0, 1, 1, 2, 3, 5, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11)
+#            1, 2, 3, 4, 5, 6, 7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25
+SCORES = (0, 0, 0, 1, 1, 2, 3, 5, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11)
 LETTER_A = ord("a")
 LETTER_Q = ord("q") - LETTER_A
 LETTER_Z = ord("z")

--- a/boggle/boggler_test.py
+++ b/boggle/boggler_test.py
@@ -69,6 +69,7 @@ def test55(get_trie, Boggler):
     t = get_trie()
     b = Boggler(t, (5, 5))
     assert b.score("sepesdsracietilmanesligdr") == 10406
+    assert b.score("ititinstietbulseutiarsaba") == 810
 
 
 def test_find_words():

--- a/cpp/boggler.h
+++ b/cpp/boggler.h
@@ -9,7 +9,12 @@
 template <int M, int N>
 class Boggler {
  public:
-  Boggler(Trie* t) : dict_(t), runs_(0) {}
+  Boggler(Trie* t) : dict_(t), runs_(0) {
+    static_assert(
+        sizeof(kWordScores) / sizeof(kWordScores[0]) - 1 >= M * N,
+        "kWordScores must have at least M * N + 1 elements"
+    );
+  }
 
   int Score(const char* lets);
 

--- a/cpp/constants.h
+++ b/cpp/constants.h
@@ -7,8 +7,8 @@
 // This prevents reading uninitialized memory on words with lots of Qus, which
 // can cause spuriously high scores.
 const unsigned int kWordScores[] = {
-    // 1, 2, 3, 4, 5, 6, 7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
-    0, 0, 0, 1, 1, 2, 3, 5, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11};
+    // 1, 2, 3, 4, 5, 6, 7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25
+    0, 0, 0, 1, 1, 2, 3, 5, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11};
 
 // clang-format on
 

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -27,8 +27,8 @@
       // const board = "abcdefghijklmnop";
       const board = "perslatgsineters";
 
-      //                 1, 2, 3, 4, 5, 6, 7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
-      const scores = [0, 0, 0, 1, 1, 2, 3, 5, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11];
+      //                 1, 2, 3, 4, 5, 6, 7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25
+      const scores = [0, 0, 0, 1, 1, 2, 3, 5, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11];
       const boggler = new Module.Boggler(trie);
       startMs = performance.now();
       const words = boggler.find_words(board, false);


### PR DESCRIPTION
Extend `kWordScores` to support 25 character long words.

`ititinstietbulseutiarsaba` is an example where `score` would return 799 instead of 810.
