### PR TITLE
Add `--variations_on` flag to perf script

### DIFF
--- a/boggle/perf.py
+++ b/boggle/perf.py
@@ -14,6 +14,7 @@ import time
 
 from boggle.args import add_standard_args, get_trie_and_boggler_from_args
 from boggle.boggler import LETTER_A
+from boggle.hillclimb import neighbors
 
 
 def random_board(n: int) -> str:
@@ -31,7 +32,19 @@ def main():
         type=str,
         help="Use this file instead of generating random boards.",
     )
-    parser.add_argument("num_boards", type=int, help="Number of boards to evaluate")
+    parser.add_argument(
+        "--variations_on",
+        type=str,
+        help="Generate 1- and 2-cell variations on this board. Useful for "
+        "testing performance on high-scoring boards.",
+    )
+    parser.add_argument(
+        "num_boards",
+        type=int,
+        help="Number of boards to evaluate",
+        default=100_000,
+        nargs="?",
+    )
     args = parser.parse_args()
     if args.random_seed >= 0:
         random.seed(args.random_seed)
@@ -40,14 +53,24 @@ def main():
     t, boggler = get_trie_and_boggler_from_args(args)
 
     w, h = args.size // 10, args.size % 10
-    if not args.input_file:
-        print(f"Generating {n} {w}x{h} boards...")
-        boards = [random_board(w * h) for _ in range(n)]
-    else:
+    if args.variations_on:
+        board = args.variations_on
+        assert len(board) == w * h
+        boards1 = neighbors(board)
+        boards = {bd for n1 in boards1 for bd in neighbors(n1)}
+        boards.update(boards1)
+        boards.add(board)
+        boards = [*boards]
+        print(f"Generated {len(boards)} neighbors of {board}")
+    elif args.input_file:
         boards = [line.strip() for line in open(args.input_file)]
         for board in boards:
             assert len(board) == w * h
         print(f"Read {len(boards)} boards from {args.input_file}")
+    else:
+        print(f"Generating {n} {w}x{h} boards...")
+        boards = [random_board(w * h) for _ in range(n)]
+
     total_score = 0
     print("Scoring boards...")
     start_s = time.time()


### PR DESCRIPTION
This lets you test performance on high-scoring boards, which can be quite different than random boards.

```
$ poetry run python -m boggle.perf --size 55 --random_seed 2025
Generating 100000 5x5 boards...
Scoring boards...
total_score=9002739
1.11s, 89721.82 bds/sec

$ poetry run python -m boggle.perf --size 55 --variations_on ligdrmanesietildsracsepes
Generated 386202 neighbors of ligdrmanesietildsracsepes
Scoring boards...
total_score=2292392284
45.32s, 8521.02 bds/sec
```

(This is to test #104)