### PR TITLE
Force til you break (drop orderly bound)

### DIFF
--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -168,10 +168,8 @@ def get_breaker(args) -> BreakingBundle:
 
     t, boggler = get_trie_and_boggler_from_args(args)
 
-    builder = OrderlyTreeBuilder if args.python else cpp_orderly_tree_builder
-    etb = builder(t, dims)
-
     if args.breaker == "hybrid":
+        etb = (OrderlyTreeBuilder if args.python else cpp_orderly_tree_builder)(t, dims)
         switchover_score = args.switchover_score or 2.5 * best_score
         breaker = HybridTreeBreaker(
             etb,
@@ -180,6 +178,7 @@ def get_breaker(args) -> BreakingBundle:
             best_score,
             switchover_score=switchover_score,
             log_breaker_progress=args.log_breaker_progress,
+            max_depth=args.max_force_depth,
         )
     elif args.breaker == "ibuckets":
         etb = (PyBucketBoggler if args.python else cpp_bucket_boggler)(t, dims)
@@ -243,6 +242,13 @@ def main():
         help="When to switch from splitting the tree by forcing cells to evaluating the "
         "remaining tree with a DFS. Higher values will use less RAM but potentially run "
         "more slowly. The default is 2.5 * best_score.",
+    )
+    parser.add_argument(
+        "--max_force_depth",
+        type=int,
+        default=None,
+        help="Maximum depth to force to before switching to orderly_bound. "
+        "This can increase speed at the cost of additional memory. Default is WxH-4.",
     )
     parser.add_argument(
         "--breaker",

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -140,6 +140,7 @@ def break_worker(task: str | int):
         if args.omit_times:
             del summary["elapsed_s"]
             del summary["secs_by_level"]
+            del summary["score_secs"]
         out.write(json.dumps(summary))
         out.write("\n")
         if args.log_per_board_stats:

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -145,7 +145,7 @@ class HybridTreeBreaker:
             self.details_.elim_level[level] += 1
         elif len(choices) == self.num_cells:
             # This is a complete board with a bound > self.best_score. Check if it's for real.
-            self.check_complete_board(choices)
+            self.check_complete_board(tree.bound, choices)
         else:
             self.force_and_filter(tree, level, choices, arena)
 
@@ -189,10 +189,13 @@ class HybridTreeBreaker:
         choices.pop()
         arena.reset_level(arena_level)
 
-    def check_complete_board(self, choices: list[tuple[int, int]]) -> None:
+    def check_complete_board(self, bound: int, choices: list[tuple[int, int]]) -> None:
         start_s = time.time()
         self.details_.boards_to_test += 1
-        board = "".join(self.cells[cell][letter] for cell, letter in choices)
+        cells = [None] * self.num_cells
+        for cell, letter in choices:
+            cells[cell] = self.cells[cell][letter]
+        board = "".join(cells)
         true_score = self.boggler.score(board)
         elapsed_s = time.time() - start_s
 

--- a/boggle/breaker_test.py
+++ b/boggle/breaker_test.py
@@ -46,6 +46,7 @@ def test_breaker(is_python):
     # blank out non-deterministic fields
     details.secs_by_level = {}
     details.elapsed_s = 0.0
+    details.score_secs = 0.0
 
     # poetry run python -m boggle.exhaustive_search --size 22 15 'aeiou lnrsy chkmpt aeiou' --python
     # 16 alte
@@ -60,17 +61,18 @@ def test_breaker(is_python):
             "num_reps": 750,
             "elapsed_s": 0.0,
             "failures": ["alte", "aste", "elta", "esta"],
-            "elim_level": {2: 2},
+            "elim_level": {4: 30, 5: 23, 3: 9, 2: 2},
             "secs_by_level": {},
             "bounds": {0: 21},
             "nodes": {0: 1186},
-            "depth": {2: 3},
+            "depth": {},
             "boards_to_test": 7,
             "init_nodes": 1186,
-            "total_nodes": 1864,
+            "total_nodes": 2592,
             "tree_bytes": 37952,
-            "total_bytes": 59648,
-            "n_bound": 3,
-            "n_force": 1,
+            "total_bytes": 82944,
+            "n_bound": 0,
+            "n_force": 16,
+            "score_secs": 0.0,
         }
     )

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -40,27 +40,32 @@ Found unbreakable board for 2520743: perslitesand
     "pansliteserd",
     "perslitesand"
   ],
-  "elim_level": {},
+  "elim_level": {
+    "6": 1052,
+    "7": 1773,
+    "8": 3033,
+    "9": 3748,
+    "10": 3694,
+    "11": 5713,
+    "12": 9419,
+    "13": 16366,
+    "5": 337,
+    "4": 20
+  },
   "bounds": {
     "0": 6652
   },
   "nodes": {
     "0": 2641103
   },
-  "depth": {
-    "3": 20,
-    "4": 18,
-    "5": 9,
-    "6": 5,
-    "2": 1
-  },
+  "depth": {},
   "boards_to_test": 8078,
   "init_nodes": 2641103,
-  "total_nodes": 4053634,
+  "total_nodes": 16345044,
   "tree_bytes": 67108864,
   "total_bytes": 134217728,
-  "n_bound": 53,
-  "n_force": 12
+  "n_bound": 0,
+  "n_force": 10369
 }
 Found 12 breaking failure(s):
 cerslatesind


### PR DESCRIPTION
This seems to be a nice performance win (~20%) with minimal memory impact.

Two nice consequences of this are:

- Eliminates two parameters, `--switchover_score` and `max_depth`
- I don't need to explain or justify `orderly_bound` in my paper.