### PR TITLE
Track it all, exclusive score cutoff

### DIFF
--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -140,6 +140,8 @@ def break_worker(task: str | int):
         if args.omit_times:
             del summary["elapsed_s"]
             del summary["secs_by_level"]
+            del summary["test_secs"]
+            del summary["bound_secs"]
         out.write(json.dumps(summary))
         out.write("\n")
         if args.log_per_board_stats:

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -17,12 +17,23 @@ import dataclasses
 import time
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+from typing import Optional
 
 from boggle.arena import PyArena
 from boggle.boggler import PyBoggler
 from boggle.eval_node import SumNode
 from boggle.orderly_tree_builder import OrderlyTreeBuilder
 from boggle.split_order import SPLIT_ORDER
+
+
+def counter_to_array(c: Counter):
+    m = max(c.keys())
+    return [c.get(k, 0) for k in range(0, m + 1)]
+
+
+def float_dict_to_array(c: defaultdict[int, float]):
+    m = max(c.keys())
+    return [round(c.get(k, 0), 5) for k in range(0, m + 1)]
 
 
 @dataclass
@@ -37,27 +48,47 @@ class BreakDetails:
 
     def asdict(self):
         d = dataclasses.asdict(self)
-        d["elim_level"] = dict(self.elim_level.items())
-        d["secs_by_level"] = dict(self.secs_by_level.items())
+        d["elapsed_s"] = round(self.elapsed_s, 5)
+        d["elim_level"] = counter_to_array(self.elim_level)
+        d["secs_by_level"] = float_dict_to_array(self.secs_by_level)
         return d
 
 
 @dataclass
 class HybridBreakDetails(BreakDetails):
     bounds: dict[int, int]
-    nodes: dict[int, int]
+    """Maximum bound at each depth."""
     depth: Counter[int]
+    """This is the switchover depth"""
     boards_to_test: int
+    """Number of boards that made it through to the Boggler"""
     init_nodes: int
+    """Number of nodes in the initial orderly tree"""
     total_nodes: int
+    """Total nodes ever allocated (not necessarily all at once)"""
     tree_bytes: int
+    """Number of bytes used by the initial orderly tree"""
     total_bytes: int
+    """Max bytes ever used while breaking"""
     n_bound: int
+    """Number of calls to orderly_bound"""
     n_force: int
+    """Number of calls to orderly_force"""
+    max_multi: int
+    """Highest-observed bound (multiboggle score) from orderly_bound"""
+    bound_secs: defaultdict[int, float]
+    """Seconds spent in orderly_bound, by level"""
+    test_secs: float
+    """Seconds spent evaluating individual boards."""
+    best_board: Optional[tuple[int, str]]
+    """Highest-scoring board that was evaluated (if any did)"""
 
     def asdict(self):
         d = super().asdict()
-        d["depth"] = dict(self.depth.items())
+        d["bounds"] = counter_to_array(self.bounds)
+        d["depth"] = counter_to_array(self.depth)
+        d["bound_secs"] = float_dict_to_array(self.bound_secs)
+        d["test_secs"] = round(self.test_secs, 5)
         return d
 
 
@@ -105,12 +136,15 @@ class HybridTreeBreaker:
             boards_to_test=0,
             init_nodes=0,
             depth=Counter(),
-            nodes={},
             total_nodes=0,
             tree_bytes=0,
             total_bytes=0,
             n_bound=0,
             n_force=0,
+            max_multi=0,
+            bound_secs=defaultdict(float),
+            test_secs=0.0,
+            best_board=None,
         )
         self.orig_reps_ = self.details_.num_reps = self.etb.NumReps()
         start_time_s = time.time()
@@ -124,7 +158,6 @@ class HybridTreeBreaker:
         self.details_.bounds[0] = tree.bound
         self.details_.init_nodes = arena.num_nodes()
         self.details_.tree_bytes = arena.bytes_allocated()
-        self.details_.nodes[0] = self.details_.init_nodes
 
         self.attack_tree(tree, 1, [], arena)
 
@@ -140,7 +173,10 @@ class HybridTreeBreaker:
         choices: list[tuple[int, int]],
         arena: PyArena,
     ) -> None:
-        if tree.bound <= self.best_score:
+        self.details_.bounds[level] = max(
+            self.details_.bounds.get(level, 0), tree.bound
+        )
+        if tree.bound < self.best_score:
             self.details_.elim_level[level] += 1
         elif tree.bound <= self.switchover_score or level > self.switchover_depth:
             self.switch_to_score(tree, level, choices)
@@ -195,18 +231,12 @@ class HybridTreeBreaker:
         # TODO: make this just return the boards
         self.details_.n_bound += 1
         self.details_.depth[level] += 1
-        # print(choices, tree.bound)
-        score_boards, bound_level, elim_level = tree.orderly_bound(
+        score_boards = tree.orderly_bound(
             self.best_score, self.cells, remaining_cells, choices
         )
-        # for i, ev in enumerate(elim_level):
-        #     bv = bound_level[i]
-        #     self.details_.bound_elim_level[i + len(choices)] += ev
-        #     self.details_.bound_level[i + len(choices)] += bv
-        # print(time.time() - start_s, seq, tree.bound, this_failures)
         boards_to_test = [board for _score, board in score_boards]
         bound_elapsed_s = time.time() - start_s
-        self.details_.secs_by_level[level] += bound_elapsed_s
+        self.details_.bound_secs[level] += bound_elapsed_s
 
         if not boards_to_test:
             if self.log_breaker_progress:
@@ -216,16 +246,22 @@ class HybridTreeBreaker:
                 )
             return
 
+        max_multi = max(score for score, _board in score_boards)
+        self.details_.max_multi = max(self.details_.max_multi, max_multi)
         self.details_.boards_to_test += len(boards_to_test)
         start_s = time.time()
+        best_board = self.details_.best_board or (-1, "")
         for board in boards_to_test:
             true_score = self.boggler.score(board)
             # print(f"{board}: {tree.bound} -> {true_score}")
             if true_score >= self.best_score:
                 print(f"Unable to break board: {board} {true_score}")
                 self.details_.failures.append(board)
+            if true_score > best_board[0]:
+                best_board = (true_score, board)
         elapsed_s = time.time() - start_s
-        self.details_.secs_by_level[level + 1] += elapsed_s
+        self.details_.test_secs += elapsed_s
+        self.details_.best_board = best_board
 
         if self.log_breaker_progress:
             time_fmt = time.strftime("%Y-%m-%d %H:%M:%S")

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -27,11 +27,15 @@ from boggle.split_order import SPLIT_ORDER
 
 
 def counter_to_array(c: Counter):
+    if not c:
+        return []
     m = max(c.keys())
     return [c.get(k, 0) for k in range(0, m + 1)]
 
 
 def float_dict_to_array(c: defaultdict[int, float]):
+    if not c:
+        return []
     m = max(c.keys())
     return [round(c.get(k, 0), 5) for k in range(0, m + 1)]
 

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -89,7 +89,7 @@ class HybridBreakDetails(BreakDetails):
 
     def asdict(self):
         d = super().asdict()
-        d["bounds"] = counter_to_array(self.bounds)
+        d["bounds"] = counter_to_array(self.bounds)[1:]
         d["depth"] = counter_to_array(self.depth)
         d["bound_secs"] = float_dict_to_array(self.bound_secs)
         d["test_secs"] = round(self.test_secs, 5)
@@ -159,7 +159,6 @@ class HybridTreeBreaker:
             print(f"root {tree.bound=}, {num_nodes} nodes")
 
         self.details_.secs_by_level[0] += time.time() - start_time_s
-        self.details_.bounds[0] = tree.bound
         self.details_.init_nodes = arena.num_nodes()
         self.details_.tree_bytes = arena.bytes_allocated()
 

--- a/boggle/breaker_test.py
+++ b/boggle/breaker_test.py
@@ -44,8 +44,10 @@ def test_breaker(is_python):
     breaker.SetBoard(board)
     details = breaker.Break()
     # blank out non-deterministic fields
-    details.secs_by_level = {}
+    details.secs_by_level = []
     details.elapsed_s = 0.0
+    details.test_secs = 0.0
+    details.bound_secs = []
 
     # poetry run python -m boggle.exhaustive_search --size 22 15 'aeiou lnrsy chkmpt aeiou' --python
     # 16 alte
@@ -59,18 +61,21 @@ def test_breaker(is_python):
         {
             "num_reps": 750,
             "elapsed_s": 0.0,
-            "failures": ["alte", "aste", "elta", "esta"],
-            "elim_level": {2: 2},
-            "secs_by_level": {},
-            "bounds": {0: 21},
-            "nodes": {0: 1186},
-            "depth": {2: 3},
-            "boards_to_test": 7,
+            "failures": ["alte", "arte", "aste", "elta", "erta", "esta"],
+            "elim_level": [0, 0, 2],
+            "secs_by_level": [],
+            "bounds": [21, 21, 19],
+            "depth": [0, 0, 3],
+            "boards_to_test": 9,
             "init_nodes": 1186,
             "total_nodes": 1864,
             "tree_bytes": 37952,
             "total_bytes": 59648,
             "n_bound": 3,
             "n_force": 1,
+            "max_multi": 18,
+            "bound_secs": [],
+            "test_secs": 0.0,
+            "best_board": (18, "aste"),
         }
     )

--- a/boggle/breaker_test.py
+++ b/boggle/breaker_test.py
@@ -64,7 +64,7 @@ def test_breaker(is_python):
             "failures": ["alte", "arte", "aste", "elta", "erta", "esta"],
             "elim_level": [0, 0, 2],
             "secs_by_level": [],
-            "bounds": [21, 21, 19],
+            "bounds": [21, 19],
             "depth": [0, 0, 3],
             "boards_to_test": 9,
             "init_nodes": 1186,

--- a/boggle/breaker_test.py
+++ b/boggle/breaker_test.py
@@ -23,7 +23,7 @@ def get_trie_otb(dict_file: str, dims: tuple[int, int], is_python: bool):
     "is_python",
     [
         True,
-        # False
+        # False -- the byte and node counts don't agree
     ],
 )
 def test_breaker(is_python):

--- a/boggle/eval_node.py
+++ b/boggle/eval_node.py
@@ -190,7 +190,7 @@ class SumNode:
             bound = base_points + sum(
                 stack_sums[cell] for cell in split_order[num_splits:]
             )
-            if bound <= cutoff:
+            if bound < cutoff:
                 elim_at_level[num_splits] += 1
                 return  # done!
             if num_splits == len(split_order):
@@ -228,7 +228,8 @@ class SumNode:
         base_points = advance(self, sums)
         rec(base_points, 0, sums)
         self.num_visits = num_visits  # for visualizing backtracking behavior
-        return failures, visit_at_level, elim_at_level
+        # return failures, visit_at_level, elim_at_level
+        return failures
 
     # --- Methods below here are only for testing / debugging and may not have C++ equivalents. ---
 

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -125,7 +125,9 @@ def test_orderly_bound22_best(make_trie, get_tree_builder):
             (18, "saet"),
             (17, "saer"),
             (20, "teat"),
+            (15, "tear"),
             (20, "taet"),
+            (15, "taer"),
         ]
     )
 

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -98,7 +98,7 @@ def test_orderly_bound22(is_python):
         t.assert_invariants(otb)
     assert t.bound == 8
 
-    failures, _, _ = t.orderly_bound(6, cells, SPLIT_ORDER[(2, 2)], [])
+    failures = t.orderly_bound(6, cells, SPLIT_ORDER[(2, 2)], [])
     assert failures == [(8, "adeg"), (7, "adeh")]
 
 
@@ -116,7 +116,7 @@ def test_orderly_bound22_best(make_trie, get_tree_builder):
         t.assert_invariants(otb)
     assert t.bound == 22
 
-    failures, _, _ = t.orderly_bound(15, cells, SPLIT_ORDER[(2, 2)], [])
+    failures = t.orderly_bound(15, cells, SPLIT_ORDER[(2, 2)], [])
     assert failures == snapshot(
         [
             (18, "seer"),
@@ -222,7 +222,7 @@ def test_orderly_bound33(make_trie, get_tree_builder):
 
     # node_counts = t.node_counts()
     start_s = time.time()
-    failures, _, _ = t.orderly_bound(500, cells, SPLIT_ORDER[(3, 3)], [])
+    failures = t.orderly_bound(500, cells, SPLIT_ORDER[(3, 3)], [])
     print(time.time() - start_s)
     # break_all reports 889 points for this board, but ibucket_solver reports 512
     assert failures == snapshot([(512, "stsaseblt")])

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -317,7 +317,7 @@ vector<pair<int, string>> SumNode::OrderlyBound(
         for (int i = num_splits; i < split_order.size(); ++i) {
           bound += stack_sums[split_order[i]];
         }
-        if (bound <= cutoff) {
+        if (bound < cutoff) {
           return;  // done!
         }
         if (num_splits == split_order.size()) {

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -289,7 +289,7 @@ inline uint16_t advance(
   return node->points_;
 }
 
-tuple<vector<pair<int, string>>, vector<int>, vector<int>> SumNode::OrderlyBound(
+vector<pair<int, string>> SumNode::OrderlyBound(
     int cutoff,
     const vector<string>& cells,
     const vector<int>& split_order,
@@ -299,9 +299,6 @@ tuple<vector<pair<int, string>>, vector<int>, vector<int>> SumNode::OrderlyBound
   vector<pair<int, int>> choices;
   vector<int> stack_sums(cells.size(), 0);
   vector<pair<int, string>> failures;
-  int n_preset = preset_cells.size();
-  vector<int> elim_at_level(1 + cells.size() - n_preset, 0);
-  vector<int> visit_at_level(1 + cells.size() - n_preset, 0);
 
   auto record_failure = [&](int bound) {
     string board(cells.size(), '.');
@@ -321,7 +318,6 @@ tuple<vector<pair<int, string>>, vector<int>, vector<int>> SumNode::OrderlyBound
           bound += stack_sums[split_order[i]];
         }
         if (bound <= cutoff) {
-          // elim_at_level[num_splits] += 1;
           return;  // done!
         }
         if (num_splits == split_order.size()) {
@@ -340,7 +336,6 @@ tuple<vector<pair<int, string>>, vector<int>, vector<int>> SumNode::OrderlyBound
         vector<pair<SumNode* const*, SumNode* const*>> its;
         its.reserve(next_stack.size());
         for (auto& n : next_stack) {
-          // assert(n->letter_ == CHOICE_NODE);
           // assert(n->cell_ == next_to_split);
           its.push_back({&n->children_[0], &n->children_[n->num_children_]});
         }
@@ -371,10 +366,9 @@ tuple<vector<pair<int, string>>, vector<int>, vector<int>> SumNode::OrderlyBound
       };
 
   vector<int> sums(cells.size(), 0);
-  // visit_at_level[0] += 1;
   auto base_points = advance(this, sums, stacks);
   rec(base_points, 0, sums);
-  return {failures, visit_at_level, elim_at_level};
+  return failures;
 }
 
 SumNode* merge_orderly_tree(const SumNode* a, const SumNode* b, EvalNodeArena& arena);

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -53,7 +53,7 @@ class SumNode {
   int NodeCount() const;
   uint32_t Bound() const { return bound_; }
 
-  tuple<vector<pair<int, string>>, vector<int>, vector<int>> OrderlyBound(
+  vector<pair<int, string>> OrderlyBound(
       int cutoff,
       const vector<string>& cells,
       const vector<int>& split_order,

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -43,7 +43,6 @@ Found unbreakable board for 2520743: perslitesand
   "elim_level": [],
   "bounds": [
     6652,
-    6652,
     5691,
     4728,
     4122,

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -40,27 +40,37 @@ Found unbreakable board for 2520743: perslitesand
     "pansliteserd",
     "perslitesand"
   ],
-  "elim_level": {},
-  "bounds": {
-    "0": 6652
-  },
-  "nodes": {
-    "0": 2641103
-  },
-  "depth": {
-    "3": 20,
-    "4": 18,
-    "5": 9,
-    "6": 5,
-    "2": 1
-  },
-  "boards_to_test": 8078,
+  "elim_level": [],
+  "bounds": [
+    6652,
+    6652,
+    5691,
+    4728,
+    4122,
+    3700,
+    3270
+  ],
+  "depth": [
+    0,
+    0,
+    1,
+    20,
+    18,
+    9,
+    5
+  ],
+  "boards_to_test": 8133,
   "init_nodes": 2641103,
   "total_nodes": 4053634,
   "tree_bytes": 67108864,
   "total_bytes": 134217728,
   "n_bound": 53,
-  "n_force": 12
+  "n_force": 12,
+  "max_multi": 2509,
+  "best_board": [
+    1651,
+    "perslatesind"
+  ]
 }
 Found 12 breaking failure(s):
 cerslatesind


### PR DESCRIPTION
Fixes #89 

This also fixes a long-standing issue where the score cutoff was inclusive in some places but exclusive in others. Now, if you run `break_all.py` with a threshold of 3500, it will return all boards with a score >= 3500.

It's possible that this has a small (~1%) impact on performance. The JSON output tends to be a smidge smaller thanks to rounding the decimals.