### PR TITLE
Replace orderly_choices with bitmap

### DIFF
--- a/boggle/eval_node_test.py
+++ b/boggle/eval_node_test.py
@@ -32,7 +32,6 @@ def test_add_word(create_arena):
     root.add_word([2, 1, 1], used_ordered, other_order, 1, arena)  # dre
 
     # This asserts that the C++ and Python trees stay in sync
-    print(eval_node_to_string(root, cells))
     assert outsource(eval_node_to_string(root, cells)) == snapshot(
         external("8cd3c17dadcd*.txt")
     )

--- a/boggle/eval_node_test.py
+++ b/boggle/eval_node_test.py
@@ -1,4 +1,5 @@
 import pytest
+from boggle.split_order import SPLIT_ORDER
 from cpp_boggle import create_eval_node_arena
 from inline_snapshot import external, outsource, snapshot
 
@@ -15,17 +16,23 @@ def test_add_word(create_arena):
     arena = create_arena()
     root = arena.new_root_node_with_capacity(4)
     cells = ["bcd", "aei", "nrd"]
-    root.add_word([(0, 0), (1, 0), (2, 0)], 1, arena)  # ban
-    root.add_word([(0, 1), (1, 0), (2, 0)], 1, arena)  # can
-    root.add_word([(0, 0), (1, 0), (2, 1)], 1, arena)  # bar
-    root.add_word([(0, 0), (1, 1), (2, 2)], 1, arena)  # bed
-    root.add_word([(0, 0), (1, 2), (2, 2)], 1, arena)  # bid
-    root.add_word([(0, 2), (1, 2), (2, 2)], 1, arena)  # did
-    root.add_word([(0, 2), (2, 1), (1, 1)], 1, arena)  # dre
 
-    # print(root.to_dot(cells))
+    regular_order = [0, 1, 2]
+    other_order = [0, 2, 1]
+
+    # all three choices are used
+    used_ordered = 0b111
+
+    root.add_word([0, 0, 0], used_ordered, regular_order, 1, arena)  # ban
+    root.add_word([1, 0, 0], used_ordered, regular_order, 1, arena)  # can
+    root.add_word([0, 0, 1], used_ordered, regular_order, 1, arena)  # bar
+    root.add_word([0, 1, 2], used_ordered, regular_order, 1, arena)  # bed
+    root.add_word([0, 2, 2], used_ordered, regular_order, 1, arena)  # bid
+    root.add_word([2, 2, 2], used_ordered, regular_order, 1, arena)  # did
+    root.add_word([2, 1, 1], used_ordered, other_order, 1, arena)  # dre
 
     # This asserts that the C++ and Python trees stay in sync
+    print(eval_node_to_string(root, cells))
     assert outsource(eval_node_to_string(root, cells)) == snapshot(
         external("8cd3c17dadcd*.txt")
     )

--- a/cpp/board_class_boggler.h
+++ b/cpp/board_class_boggler.h
@@ -10,7 +10,7 @@
 template <int M, int N>
 class BoardClassBoggler {
  public:
-  BoardClassBoggler(Trie* t) : dict_(t), used_(0) {}
+  BoardClassBoggler(Trie* t) : dict_(t), used_(0), used_ordered_(0) {}
   virtual ~BoardClassBoggler() {}
 
   // bd is a class of boards with cells delimited by spaces.
@@ -34,6 +34,7 @@ class BoardClassBoggler {
   Trie* dict_;
   char bd_[M * N][27];  // null-terminated lists of possible letters
   unsigned int used_;
+  unsigned int used_ordered_; // used cells mapped to their split order
   char board_rep_[27 * M * N];  // for as_string()
 };
 

--- a/cpp/board_class_boggler.h
+++ b/cpp/board_class_boggler.h
@@ -10,7 +10,7 @@
 template <int M, int N>
 class BoardClassBoggler {
  public:
-  BoardClassBoggler(Trie* t) : dict_(t), used_(0), used_ordered_(0) {}
+  BoardClassBoggler(Trie* t) : dict_(t), used_(0) {}
   virtual ~BoardClassBoggler() {}
 
   // bd is a class of boards with cells delimited by spaces.
@@ -34,7 +34,6 @@ class BoardClassBoggler {
   Trie* dict_;
   char bd_[M * N][27];  // null-terminated lists of possible letters
   unsigned int used_;
-  unsigned int used_ordered_; // used cells mapped to their split order
   char board_rep_[27 * M * N];  // for as_string()
 };
 

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -25,15 +25,14 @@ class SumNode {
   void AddWord(
       vector<int> choices,
       unsigned int used_ordered,
-      const int* split_order,
+      vector<int> split_order,
       int points,
       EvalNodeArena& arena);
 
   SumNode* AddWordWork(
-      int* choices,
+      int choices[],
       unsigned int used_ordered,
-      const int* split_order,
-      const int* num_letters,
+      const int split_order[],
       int points,
       EvalNodeArena& arena
   );

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -22,10 +22,17 @@ class SumNode {
   SumNode() : points_(0), num_children_(0) {}
   ~SumNode() {}
 
-  void AddWord(vector<pair<int, int>> choices, int points, EvalNodeArena& arena);
+  void AddWord(
+      vector<int> choices,
+      unsigned int used_ordered,
+      const int* split_order,
+      int points,
+      EvalNodeArena& arena);
+
   SumNode* AddWordWork(
-      int num_choices,
-      pair<int, int>* choices,
+      int* choices,
+      unsigned int used_ordered,
+      const int* split_order,
       const int* num_letters,
       int points,
       EvalNodeArena& arena


### PR DESCRIPTION
Use a bitmap of cell orders instead of explicitly keeping the choices list. Small performance improvement.

`main`:
```
poetry run python -m boggle.orderly_tree_builder "bcdfgh aeijou hklnty aeiosuy hklnty aeijou hklnty bcdfgmpqvwxz hklnty aeijou hklnty aeijou bcdfgh aeijou hklnty aeiosuy"
1.29s OrderlyTreeBuilder: t.bound=28247, 10206378 nodes
poetry run python -m boggle.orderly_tree_builder "bcdfghjklmnpqrtvwxz aeijou hklnrsty aeiosuy hklnrsty aeijou hklnrsty bcdfgmpqvwxz hklnrsty aeijou hklnrsty aeijou bcdfghjklmnpqrtvwxz aeijou hklnrsty aeiosuy"
19.58s OrderlyTreeBuilder: t.bound=67827, 140698054 nodes
poetry run python -m boggle.orderly_tree_builder "lnrsy aeiou chkmpt chkmpt aeiou lnrsy lnrsy aeiou bdfgjvwxz"
0.05s OrderlyTreeBuilder: t.bound=1449, 332438 nodes
```

branch:
```
poetry run python -m boggle.orderly_tree_builder "bcdfgh aeijou hklnty aeiosuy hklnty aeijou hklnty bcdfgmpqvwxz hklnty aeijou hklnty aeijou bcdfgh aeijou hklnty aeiosuy"
1.08s OrderlyTreeBuilder: t.bound=28247, 10206378 nodes
poetry run python -m boggle.orderly_tree_builder "bcdfghjklmnpqrtvwxz aeijou hklnrsty aeiosuy hklnrsty aeijou hklnrsty bcdfgmpqvwxz hklnrsty aeijou hklnrsty aeijou bcdfghjklmnpqrtvwxz aeijou hklnrsty aeiosuy"
18.08s OrderlyTreeBuilder: t.bound=67827, 140698054 nodes
poetry run python -m boggle.orderly_tree_builder "lnrsy aeiou chkmpt chkmpt aeiou lnrsy lnrsy aeiou bdfgjvwxz"
0.05s OrderlyTreeBuilder: t.bound=1449, 332438 nodes
```

Closes #82.