### PR TITLE
Use fixed size arrays for stacks in OrderlyBound

### DIFF
--- a/cpp/constants.h
+++ b/cpp/constants.h
@@ -10,6 +10,10 @@ const unsigned int kWordScores[] = {
     // 1, 2, 3, 4, 5, 6, 7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25
     0, 0, 0, 1, 1, 2, 3, 5, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11};
 
+// 5x5 board, 26 letters.
+const int MAX_CELLS = 5 * 5;
+const int MAX_STACK_DEPTH = MAX_CELLS * 26;
+
 // clang-format on
 
 #endif  // CONSTANTS_H

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -7,6 +7,7 @@
 #include <new>
 #include <variant>
 #include <vector>
+
 #include "constants.h"
 
 using namespace std;
@@ -288,7 +289,10 @@ unsigned int ChoiceNode::ScoreWithForces(const vector<int>& forces) const {
 
 // block-scope functions cannot be declared inline.
 inline uint16_t advance(
-    const SumNode* node, vector<int>& sums, const ChoiceNode* stacks[MAX_CELLS][MAX_STACK_DEPTH], int stack_sizes[MAX_CELLS]
+    const SumNode* node,
+    vector<int>& sums,
+    const ChoiceNode* stacks[MAX_CELLS][MAX_STACK_DEPTH],
+    int stack_sizes[MAX_CELLS]
 ) {
   for (int i = 0; i < node->num_children_; i++) {
     auto child = node->children_[i];
@@ -350,7 +354,10 @@ vector<pair<int, string>> SumNode::OrderlyBound(
         its.reserve(stack_sizes[next_to_split]);
         for (int i = 0; i < stack_sizes[next_to_split]; i++) {
           // assert(n->cell_ == next_to_split);
-          its.push_back({&next_stack[i]->children_[0], &next_stack[i]->children_[next_stack[i]->num_children_]});
+          its.push_back(
+              {&next_stack[i]->children_[0],
+               &next_stack[i]->children_[next_stack[i]->num_children_]}
+          );
         }
 
         int num_letters = cells[next_to_split].size();

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -7,6 +7,7 @@
 #include <new>
 #include <variant>
 #include <vector>
+#include "constants.h"
 
 using namespace std;
 
@@ -287,11 +288,11 @@ unsigned int ChoiceNode::ScoreWithForces(const vector<int>& forces) const {
 
 // block-scope functions cannot be declared inline.
 inline uint16_t advance(
-    const SumNode* node, vector<int>& sums, vector<vector<const ChoiceNode*>>& stacks
+    const SumNode* node, vector<int>& sums, const ChoiceNode* stacks[MAX_CELLS][MAX_STACK_DEPTH], int stack_sizes[MAX_CELLS]
 ) {
   for (int i = 0; i < node->num_children_; i++) {
     auto child = node->children_[i];
-    stacks[child->cell_].push_back(child);
+    stacks[child->cell_][stack_sizes[child->cell_]++] = child;
     sums[child->cell_] += child->bound_;
   }
   return node->points_;
@@ -303,7 +304,11 @@ vector<pair<int, string>> SumNode::OrderlyBound(
     const vector<int>& split_order,
     const vector<pair<int, int>>& preset_cells
 ) const {
-  vector<vector<const ChoiceNode*>> stacks(cells.size());
+  const ChoiceNode* stacks[MAX_CELLS][MAX_STACK_DEPTH];
+  int stack_sizes[MAX_CELLS];
+  for (int i = 0; i < MAX_CELLS; i++) {
+    stack_sizes[i] = 0;
+  }
   vector<pair<int, int>> choices;
   vector<int> stack_sums(cells.size(), 0);
   vector<pair<int, string>> failures;
@@ -334,18 +339,18 @@ vector<pair<int, string>> SumNode::OrderlyBound(
         }
 
         int next_to_split = split_order[num_splits];
-        vector<int> stack_top(stacks.size());
-        for (int i = 0; i < stacks.size(); ++i) {
-          stack_top[i] = stacks[i].size();
+        int base_stack_sizes[MAX_CELLS];
+        for (int i = 0; i < MAX_CELLS; i++) {
+          base_stack_sizes[i] = stack_sizes[i];
         }
         vector<int> base_sums = stack_sums;
 
         auto& next_stack = stacks[next_to_split];
         vector<pair<SumNode* const*, SumNode* const*>> its;
-        its.reserve(next_stack.size());
-        for (auto& n : next_stack) {
+        its.reserve(stack_sizes[next_to_split]);
+        for (int i = 0; i < stack_sizes[next_to_split]; i++) {
           // assert(n->cell_ == next_to_split);
-          its.push_back({&n->children_[0], &n->children_[n->num_children_]});
+          its.push_back({&next_stack[i]->children_[0], &next_stack[i]->children_[next_stack[i]->num_children_]});
         }
 
         int num_letters = cells[next_to_split].size();
@@ -353,10 +358,8 @@ vector<pair<int, string>> SumNode::OrderlyBound(
           if (letter > 0) {
             // TODO: it should be possible to avoid this copy with another stack.
             stack_sums = base_sums;
-            for (int i = 0; i < stacks.size(); ++i) {
-              // This will not de-allocate anything, just reduce size.
-              // https://cplusplus.com/reference/vector/vector/resize/
-              stacks[i].resize(stack_top[i]);
+            for (int i = 0; i < MAX_CELLS; i++) {
+              stack_sizes[i] = base_stack_sizes[i];
             }
           }
           choices.emplace_back(next_to_split, letter);
@@ -364,7 +367,7 @@ vector<pair<int, string>> SumNode::OrderlyBound(
           for (auto& [it, end] : its) {
             if (it != end && (*it)->letter_ == letter) {
               // visit_at_level[1 + num_splits] += 1;
-              points += advance(*it, stack_sums, stacks);
+              points += advance(*it, stack_sums, stacks, stack_sizes);
               ++it;
             }
           }
@@ -374,7 +377,7 @@ vector<pair<int, string>> SumNode::OrderlyBound(
       };
 
   vector<int> sums(cells.size(), 0);
-  auto base_points = advance(this, sums, stacks);
+  auto base_points = advance(this, sums, stacks, stack_sizes);
   rec(base_points, 0, sums);
   return failures;
 }


### PR DESCRIPTION
Use fixed size arrays for stacks. Keep track of their lengths in a separate fixed size array. OrderlyBound is about 1.3x faster on 5x5 boards. Might need some more benchmarking.

`poetry run python -m boggle.break_all 'bdfgjqvwxz aeiou lnrsy chkmpt' 10406 --size 55 --num_threads 1 --log_breaker_progress --max_boards 10000 --random_seed 1234 --log_per_board_stats`

`main`:
```
Found 10000 canonical boards in 1.00s.
root tree.bound=58320, 14800752 nodes
2025-05-09 23:25:40 1 [(12, 0), (7, 0), (11, 0)] -> tree.bound=23483 2.26 s
2025-05-09 23:25:44 2 [(12, 0), (7, 0), (11, 1)] -> tree.bound=25220 3.5 s
2025-05-09 23:25:45 3 [(12, 0), (7, 0), (11, 2)] -> tree.bound=23312 1.23 s
2025-05-09 23:25:46 4 [(12, 0), (7, 0), (11, 3)] -> tree.bound=22738 1.51 s
2025-05-09 23:25:47 5 [(12, 0), (7, 0), (11, 4)] -> tree.bound=21239 0.619 s
2025-05-09 23:25:48 6 [(12, 0), (7, 0), (11, 5)] -> tree.bound=21872 0.786 s
2025-05-09 23:25:49 7 [(12, 0), (7, 0), (11, 6)] -> tree.bound=22697 1.07 s
2025-05-09 23:25:50 8 [(12, 0), (7, 0), (11, 7)] -> tree.bound=21996 1.05 s
2025-05-09 23:25:51 9 [(12, 0), (7, 0), (11, 8)] -> tree.bound=21787 0.746 s
2025-05-09 23:25:51 10 [(12, 0), (7, 0), (11, 9)] -> tree.bound=21622 0.694 s
2025-05-09 23:25:52 11 [(12, 0), (7, 1), (11, 0)] -> tree.bound=22645 0.796 s
2025-05-09 23:25:54 12 [(12, 0), (7, 1), (11, 1)] -> tree.bound=25584 1.48 s
2025-05-09 23:25:54 13 [(12, 0), (7, 1), (11, 2)] -> tree.bound=21836 0.388 s
2025-05-09 23:25:55 14 [(12, 0), (7, 1), (11, 3)] -> tree.bound=22504 0.631 s
2025-05-09 23:25:55 15 [(12, 0), (7, 1), (11, 4)] -> tree.bound=20285 0.191 s
2025-05-09 23:25:55 16 [(12, 0), (7, 1), (11, 5)] -> tree.bound=20890 0.248 s
2025-05-09 23:25:56 17 [(12, 0), (7, 1), (11, 6)] -> tree.bound=21912 0.384 s
2025-05-09 23:25:56 18 [(12, 0), (7, 1), (11, 7)] -> tree.bound=22112 0.45 s
2025-05-09 23:25:56 19 [(12, 0), (7, 1), (11, 8)] -> tree.bound=20825 0.228 s
2025-05-09 23:25:56 20 [(12, 0), (7, 1), (11, 9)] -> tree.bound=20592 0.246 s
2025-05-09 23:26:01 21 [(12, 0), (7, 2)] -> tree.bound=24908 4.97 s
```

branch:
```
Found 10000 canonical boards in 1.02s.
root tree.bound=58320, 14800752 nodes
2025-05-09 23:46:18 1 [(12, 0), (7, 0), (11, 0)] -> tree.bound=23483 1.71 s
2025-05-09 23:46:21 2 [(12, 0), (7, 0), (11, 1)] -> tree.bound=25220 2.63 s
2025-05-09 23:46:22 3 [(12, 0), (7, 0), (11, 2)] -> tree.bound=23312 0.973 s
2025-05-09 23:46:23 4 [(12, 0), (7, 0), (11, 3)] -> tree.bound=22738 1.17 s
2025-05-09 23:46:23 5 [(12, 0), (7, 0), (11, 4)] -> tree.bound=21239 0.586 s
2025-05-09 23:46:24 6 [(12, 0), (7, 0), (11, 5)] -> tree.bound=21872 0.665 s
2025-05-09 23:46:25 7 [(12, 0), (7, 0), (11, 6)] -> tree.bound=22697 0.819 s
2025-05-09 23:46:26 8 [(12, 0), (7, 0), (11, 7)] -> tree.bound=21996 0.766 s
2025-05-09 23:46:26 9 [(12, 0), (7, 0), (11, 8)] -> tree.bound=21787 0.55 s
2025-05-09 23:46:27 10 [(12, 0), (7, 0), (11, 9)] -> tree.bound=21622 0.491 s
2025-05-09 23:46:27 11 [(12, 0), (7, 1), (11, 0)] -> tree.bound=22645 0.575 s
2025-05-09 23:46:28 12 [(12, 0), (7, 1), (11, 1)] -> tree.bound=25584 1.13 s
2025-05-09 23:46:29 13 [(12, 0), (7, 1), (11, 2)] -> tree.bound=21836 0.287 s
2025-05-09 23:46:29 14 [(12, 0), (7, 1), (11, 3)] -> tree.bound=22504 0.474 s
2025-05-09 23:46:29 15 [(12, 0), (7, 1), (11, 4)] -> tree.bound=20285 0.135 s
2025-05-09 23:46:30 16 [(12, 0), (7, 1), (11, 5)] -> tree.bound=20890 0.175 s
2025-05-09 23:46:30 17 [(12, 0), (7, 1), (11, 6)] -> tree.bound=21912 0.284 s
2025-05-09 23:46:30 18 [(12, 0), (7, 1), (11, 7)] -> tree.bound=22112 0.329 s
2025-05-09 23:46:30 19 [(12, 0), (7, 1), (11, 8)] -> tree.bound=20825 0.173 s
2025-05-09 23:46:30 20 [(12, 0), (7, 1), (11, 9)] -> tree.bound=20592 0.16 s
2025-05-09 23:46:34 21 [(12, 0), (7, 2)] -> tree.bound=24908 3.77 s
```