### PR TITLE
Use -isystem to disable warnings for pybind11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ c++ -Wall -shared -std=c++20 -fPIC -march=native \
     -Wno-sign-compare \
     -Wshadow \
     -O3 \
-    $(poetry run python -m pybind11 --includes) \
+    $(poetry run python -m pybind11 --includes | perl -pe 's/-I/-isystem /g') \
     cpp_boggle.cc trie.cc arena.cc eval_node.cc symmetry.cc \
     -o ../cpp_boggle$(python3-config --extension-suffix) \
     $EXTRA_FLAGS

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@ cd cpp
 c++ -Wall -shared -std=c++20 -fPIC -march=native \
     -Wno-sign-compare \
     -Wshadow \
+    -Werror \
     -O3 \
     $(poetry run python -m pybind11 --includes | perl -pe 's/-I/-isystem /g') \
     cpp_boggle.cc trie.cc arena.cc eval_node.cc symmetry.cc \

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -314,7 +314,6 @@ vector<pair<int, string>> SumNode::OrderlyBound(
     stack_sizes[i] = 0;
   }
   vector<pair<int, int>> choices;
-  vector<int> stack_sums(cells.size(), 0);
   vector<pair<int, string>> failures;
 
   auto record_failure = [&](int bound) {


### PR DESCRIPTION
See https://github.com/pybind/pybind11/issues/1267. The less hacky solution seems to require Cmake, so regex it is for me.

This exposed a `-Wshadow` issue that wasn't getting reported by clang. I fixed that, too, and added `-Werror` to make these issues more visible in the future.