### PR TITLE
Consistent Python-style naming in Python

### DIFF
--- a/boggle/args.py
+++ b/boggle/args.py
@@ -46,7 +46,7 @@ def get_trie_from_args(args: argparse.Namespace):
         t = make_py_trie(args.dictionary)
         assert t
     else:
-        t = Trie.CreateFromFile(args.dictionary)
+        t = Trie.create_from_file(args.dictionary)
         assert t
     return t
 

--- a/boggle/board_class_boggler.py
+++ b/boggle/board_class_boggler.py
@@ -21,7 +21,7 @@ class BoardClassBoggler:
         self.dims = dims
         self.cells = []
 
-    def ParseBoard(self, board: str):
+    def parse_board(self, board: str):
         cells = board.split(" ")
         if len(cells) != self.dims[0] * self.dims[1] or not all(cells):
             return False
@@ -29,7 +29,7 @@ class BoardClassBoggler:
         self.bd_ = [b if b != "." else "" for b in cells]
         return True
 
-    def NumReps(self) -> int:
+    def num_reps(self) -> int:
         return math.prod(len(cell) for cell in self.bd_)
 
     def as_string(self):

--- a/boggle/boggler.py
+++ b/boggle/boggler.py
@@ -12,6 +12,8 @@ LETTER_Z = ord("z")
 class PyBoggler:
     """Hybrid or pure-Python Boggler (depending on the Trie)."""
 
+    _trie: PyTrie
+
     def __init__(self, trie, dims: tuple[int, int]):
         self._trie = trie
         self._runs = 0
@@ -24,7 +26,7 @@ class PyBoggler:
         self.words = None
         self._neighbors = NEIGHBORS[dims]
         self.lookup_table = None
-        assert not self._trie.IsWord()
+        assert not self._trie.is_word()
 
     def set_board(self, bd: str):
         assert len(bd) == self._n
@@ -41,8 +43,8 @@ class PyBoggler:
     def score(self, bd: str):
         self.set_board(bd)
         # This allows the same Trie to be used by multiple bogglers, e.g. for boggle_test.py
-        self._runs = 1 + self._trie.Mark()
-        self._trie.SetMark(self._runs)
+        self._runs = 1 + self._trie.mark()
+        self._trie.set_mark(self._runs)
         self._score = 0
         if self.collect_words:
             self.words = []
@@ -53,7 +55,7 @@ class PyBoggler:
             c = self._cells[i]
             if c == -1:
                 continue
-            d = t.Descend(c)
+            d = t.descend(c)
             if d:
                 self.do_dfs(i, 0, d)
         return self._score
@@ -62,9 +64,9 @@ class PyBoggler:
         c = self._cells[i]
         self._used[i] = True
         length += 1 if c != LETTER_Q else 2
-        if t.IsWord():
-            if t.Mark() != self._runs:
-                t.SetMark(self._runs)
+        if t.is_word():
+            if t.mark() != self._runs:
+                t.set_mark(self._runs)
                 self._score += SCORES[length]
                 if self.collect_words:
                     self.words.append(self.lookup_table[t])
@@ -74,7 +76,7 @@ class PyBoggler:
                 cc = self._cells[idx]
                 if cc == -1:
                     continue
-                d = t.Descend(cc)
+                d = t.descend(cc)
                 if d:
                     self.do_dfs(idx, length, d)
 
@@ -84,8 +86,8 @@ class PyBoggler:
         self._seq = []
         self._found_words = set()
         self.set_board(lets)
-        self._runs = self._trie.Mark() + 1
-        self._trie.SetMark(self._runs)
+        self._runs = self._trie.mark() + 1
+        self._trie.set_mark(self._runs)
         self._score = 0
         self._used = [False] * 16
         t = self._trie
@@ -94,7 +96,7 @@ class PyBoggler:
             c = self._cells[i]
             if c == -1:
                 continue
-            d = t.Descend(c)
+            d = t.descend(c)
             if d:
                 self.find_words_dfs(i, d, multiboggle, out)
         return out
@@ -105,16 +107,16 @@ class PyBoggler:
         self._used[i] = True
         self._seq.append(i)
 
-        if t.IsWord():
+        if t.is_word():
             if multiboggle:
                 key = (id(t), tuple(sorted(self._seq)))
                 should_count = key not in self._found_words
                 if should_count:
                     self._found_words.add(key)
             else:
-                should_count = t.Mark() != self._runs
+                should_count = t.mark() != self._runs
             if should_count:
-                t.SetMark(self._runs)
+                t.set_mark(self._runs)
                 out.append([*self._seq])
 
         for idx in self._neighbors[i]:
@@ -122,7 +124,7 @@ class PyBoggler:
                 cc = self._cells[idx]
                 if cc == -1:
                     continue
-                d = t.Descend(cc)
+                d = t.descend(cc)
                 if d:
                     self.find_words_dfs(idx, d, multiboggle, out)
 

--- a/boggle/boggler_test.py
+++ b/boggle/boggler_test.py
@@ -16,7 +16,7 @@ def get_py_trie():
 
 @functools.cache
 def get_cpp_trie():
-    return Trie.CreateFromFile("wordlists/enable2k.txt")
+    return Trie.create_from_file("wordlists/enable2k.txt")
 
 
 PARAMS = [

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -153,7 +153,7 @@ class HybridTreeBreaker:
         self.orig_reps_ = self.details_.num_reps = self.etb.num_reps()
         start_time_s = time.time()
         arena = self.etb.create_arena()
-        tree = self.etb.BuildTree(arena)
+        tree = self.etb.build_tree(arena)
         num_nodes = arena.num_nodes()
         if self.log_breaker_progress:
             print(f"root {tree.bound=}, {num_nodes} nodes")

--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -42,7 +42,7 @@ def float_dict_to_array(c: defaultdict[int, float]):
 
 @dataclass
 class BreakDetails:
-    """Details shared between hybrid and ibuckets."""
+    """details shared between hybrid and ibuckets."""
 
     num_reps: int
     elapsed_s: float
@@ -125,7 +125,7 @@ class HybridTreeBreaker:
         self.log_breaker_progress = log_breaker_progress
 
     def SetBoard(self, board: str):
-        return self.etb.ParseBoard(board)
+        return self.etb.parse_board(board)
 
     def Break(self) -> HybridBreakDetails:
         self.cells = self.etb.as_string().split(" ")
@@ -150,7 +150,7 @@ class HybridTreeBreaker:
             test_secs=0.0,
             best_board=None,
         )
-        self.orig_reps_ = self.details_.num_reps = self.etb.NumReps()
+        self.orig_reps_ = self.details_.num_reps = self.etb.num_reps()
         start_time_s = time.time()
         arena = self.etb.create_arena()
         tree = self.etb.BuildTree(arena)

--- a/boggle/breaker_test.py
+++ b/boggle/breaker_test.py
@@ -14,7 +14,7 @@ def get_trie_otb(dict_file: str, dims: tuple[int, int], is_python: bool):
         trie = make_py_trie(dict_file)
         otb = OrderlyTreeBuilder(trie, dims=dims)
     else:
-        trie = Trie.CreateFromFile(dict_file)
+        trie = Trie.create_from_file(dict_file)
         otb = cpp_orderly_tree_builder(trie, dims=dims)
     return trie, otb
 

--- a/boggle/bucket_descent.py
+++ b/boggle/bucket_descent.py
@@ -65,8 +65,8 @@ def bucket_score(
     scores = []
     for idx in boards:
         bd = class_for_board(buckets, classes, idx)
-        bb.ParseBoard(bd)
-        scores.append(bb.UpperBound(1_000_000))
+        bb.parse_board(bd)
+        scores.append(bb.upper_bound(1_000_000))
     return sum(scores) / len(scores)
 
 

--- a/boggle/bucket_descent.py
+++ b/boggle/bucket_descent.py
@@ -81,7 +81,7 @@ def class_to_buckets(classes: str) -> list[int]:
 
 def main():
     random.seed(2025)
-    t = Trie.CreateFromFile("wordlists/enable2k.txt")
+    t = Trie.create_from_file("wordlists/enable2k.txt")
     assert t
     num_classes = 5
     w, h = 3, 3

--- a/boggle/ibucket_breaker.py
+++ b/boggle/ibucket_breaker.py
@@ -53,7 +53,7 @@ class IBucketBreaker:
         self.log_breaker_progress = log_breaker_progress
 
     def SetBoard(self, board: str):
-        return self.bb.ParseBoard(board)
+        return self.bb.parse_board(board)
 
     def Break(self) -> IBucketBreakDetails:
         self.details_ = IBucketBreakDetails(
@@ -66,7 +66,7 @@ class IBucketBreaker:
             # root_score_bailout=None,
         )
         self.elim_ = 0
-        self.orig_reps_ = self.bb.NumReps()
+        self.orig_reps_ = self.bb.num_reps()
         start_time_s = time.time()
         self.AttackBoard()
 
@@ -116,31 +116,31 @@ class IBucketBreaker:
         for i, split in enumerate(splits):
             bd = [*cells]
             bd[cell] = split
-            # C++ version uses ParseBoard() + Cell() here.
-            assert self.bb.ParseBoard(" ".join(bd))
+            # C++ version uses parse_board() + Cell() here.
+            assert self.bb.parse_board(" ".join(bd))
             self.AttackBoard(level + 1, i + 1, len(splits))
 
     def AttackBoard(self, level: int = 0, num: int = 1, out_of: int = 1) -> None:
         # TODO: debug output
-        # reps = self.bb.NumReps()
+        # reps = self.bb.num_reps()
 
         self.details_.by_level[level] += 1
         start_s = time.time()
-        ub = self.bb.UpperBound(self.best_score)
+        ub = self.bb.upper_bound(self.best_score)
         elapsed_s = time.time() - start_s
         if self.log_breaker_progress:
             indent = " " * level
-            d = self.bb.Details()
+            d = self.bb.details()
             incomp = " (incomplete)" if ub >= self.best_score else ""
             sys.stderr.write(
                 f"{indent}{num}/{out_of} {ub}{incomp} (max={d.max_nomark}, sum={d.sum_union}) {self.bb.as_string()}\n"
             )
         self.details_.secs_by_level[level] += elapsed_s
         if level == 0:
-            # self.details_.root_score_bailout = (ub, self.bb.Details().bailout_cell)
+            # self.details_.root_score_bailout = (ub, self.bb.details().bailout_cell)
             self.details_.root_bound = ub
         if ub <= self.best_score:
-            self.elim_ += self.bb.NumReps()
+            self.elim_ += self.bb.num_reps()
             # self.details_.max_depth = max(self.details_.max_depth, level)
             self.details_.elim_level[level] += 1
         else:

--- a/boggle/ibucket_solver.py
+++ b/boggle/ibucket_solver.py
@@ -44,10 +44,10 @@ def main():
         bb.collect_words = True
 
     start_s = time.time()
-    bb.ParseBoard(board)
-    bound = bb.UpperBound(500_000)
+    bb.parse_board(board)
+    bound = bb.upper_bound(500_000)
     elapsed_s = time.time() - start_s
-    d = bb.Details()
+    d = bb.details()
     print(
         f"{elapsed_s:.02f}s {bound} (max={d.max_nomark}, sum={d.sum_union}) {bb.as_string()}"
     )

--- a/boggle/ibuckets.py
+++ b/boggle/ibuckets.py
@@ -41,8 +41,8 @@ class PyBucketBoggler(BoardClassBoggler):
     def UpperBound(self, bailout_score: int):
         self.details_ = ScoreDetails(0, 0, -1)
         self.used_ = 0
-        self.runs_ = self.trie_.Mark() + 1
-        self.trie_.SetMark(self.runs_)
+        self.runs_ = self.trie_.mark() + 1
+        self.trie_.set_mark(self.runs_)
         self.words = None
         if self.collect_words:
             self.words = []
@@ -64,9 +64,9 @@ class PyBucketBoggler(BoardClassBoggler):
         max_score = 0
         for char in self.bd_[idx]:
             cc = ord(char) - LETTER_A
-            if t.StartsWord(cc):
+            if t.starts_word(cc):
                 tscore = self.DoDFS(
-                    idx, length + (2 if cc == LETTER_Q else 1), t.Descend(cc)
+                    idx, length + (2 if cc == LETTER_Q else 1), t.descend(cc)
                 )
                 max_score = max(max_score, tscore)
         return max_score
@@ -79,15 +79,15 @@ class PyBucketBoggler(BoardClassBoggler):
             if not self.used_ & (1 << idx):
                 score += self.DoAllDescents(idx, length, t)
 
-        if t.IsWord():
+        if t.is_word():
             word_score = SCORES[length]
             score += word_score
             if self.collect_words:
                 word = self.lookup_table[t]
                 self.words.append(word)
-            if t.Mark() != self.runs_:
+            if t.mark() != self.runs_:
                 self.details_.sum_union += word_score
-                t.SetMark(self.runs_)
+                t.set_mark(self.runs_)
 
         self.used_ ^= 1 << i
         return score

--- a/boggle/ibuckets.py
+++ b/boggle/ibuckets.py
@@ -35,10 +35,10 @@ class PyBucketBoggler(BoardClassBoggler):
         self.words = None
         self.lookup_table = None
 
-    def Details(self):
+    def details(self):
         return self.details_
 
-    def UpperBound(self, bailout_score: int):
+    def upper_bound(self, bailout_score: int):
         self.details_ = ScoreDetails(0, 0, -1)
         self.used_ = 0
         self.runs_ = self.trie_.mark() + 1

--- a/boggle/ibuckets.py
+++ b/boggle/ibuckets.py
@@ -50,7 +50,7 @@ class PyBucketBoggler(BoardClassBoggler):
                 self.lookup_table = make_lookup_table(self.trie_)
 
         for i in range(len(self.bd_)):
-            max_score = self.DoAllDescents(i, 0, self.trie_)
+            max_score = self.do_all_descents(i, 0, self.trie_)
             self.details_.max_nomark += max_score
             if (
                 self.details_.max_nomark > bailout_score
@@ -60,24 +60,24 @@ class PyBucketBoggler(BoardClassBoggler):
                 break
         return min(self.details_.max_nomark, self.details_.sum_union)
 
-    def DoAllDescents(self, idx: int, length: int, t: PyTrie):
+    def do_all_descents(self, idx: int, length: int, t: PyTrie):
         max_score = 0
         for char in self.bd_[idx]:
             cc = ord(char) - LETTER_A
             if t.starts_word(cc):
-                tscore = self.DoDFS(
+                tscore = self.do_dfs(
                     idx, length + (2 if cc == LETTER_Q else 1), t.descend(cc)
                 )
                 max_score = max(max_score, tscore)
         return max_score
 
-    def DoDFS(self, i: int, length: int, t: PyTrie):
+    def do_dfs(self, i: int, length: int, t: PyTrie):
         score = 0
         self.used_ ^= 1 << i
 
         for idx in self.neighbors[i]:
             if not self.used_ & (1 << idx):
-                score += self.DoAllDescents(idx, length, t)
+                score += self.do_all_descents(idx, length, t)
 
         if t.is_word():
             word_score = SCORES[length]
@@ -91,13 +91,3 @@ class PyBucketBoggler(BoardClassBoggler):
 
         self.used_ ^= 1 << i
         return score
-
-
-class PyBucketBoggler22(PyBucketBoggler):
-    def __init__(self, trie: PyTrie):
-        super().__init__(trie, (2, 2))
-
-
-class PyBucketBoggler23(PyBucketBoggler):
-    def __init__(self, trie: PyTrie):
-        super().__init__(trie, (2, 3))

--- a/boggle/ibuckets_test.py
+++ b/boggle/ibuckets_test.py
@@ -16,18 +16,18 @@ PARAMS = [(PyBucketBoggler, PyTrie), (cpp_bucket_boggler, Trie)]
 def test_boards(Boggler: type[PyBucketBoggler], TrieT: type[PyTrie]):
     bb = Boggler(None, (3, 3))
 
-    assert not bb.ParseBoard("")
-    assert not bb.ParseBoard("abc def")
-    assert not bb.ParseBoard("a b c d e f g h i j")
-    assert not bb.ParseBoard("a b c d e  g h i")
+    assert not bb.parse_board("")
+    assert not bb.parse_board("abc def")
+    assert not bb.parse_board("a b c d e f g h i j")
+    assert not bb.parse_board("a b c d e  g h i")
 
-    assert bb.ParseBoard("a b c d e f g h i")
+    assert bb.parse_board("a b c d e f g h i")
     assert bb.as_string() == "a b c d e f g h i"
-    assert bb.NumReps() == 1
+    assert bb.num_reps() == 1
 
-    assert bb.ParseBoard("abc b c d e f g htuv pqrs")
+    assert bb.parse_board("abc b c d e f g htuv pqrs")
     assert bb.as_string() == "abc b c d e f g htuv pqrs"
-    assert 3 * 4 * 4 == bb.NumReps()
+    assert 3 * 4 * 4 == bb.num_reps()
 
 
 @pytest.mark.parametrize("Boggler, TrieT", PARAMS)
@@ -41,41 +41,41 @@ def test_bound(Boggler: type[PyBucketBoggler], TrieT: type[PyTrie]):
 
     bb = Boggler(t, (3, 3))
 
-    assert bb.ParseBoard("a b c d e f g h i")
-    assert 0 == bb.UpperBound(BIGINT)
-    assert 0 == bb.Details().sum_union
-    assert 0 == bb.Details().max_nomark
+    assert bb.parse_board("a b c d e f g h i")
+    assert 0 == bb.upper_bound(BIGINT)
+    assert 0 == bb.details().sum_union
+    assert 0 == bb.details().max_nomark
 
     # s e h
     # e a t
     # p u c
-    assert bb.ParseBoard("s e p e a u h t c")
-    score = bb.UpperBound(BIGINT)
-    assert 4 == bb.Details().sum_union  # sea(t), tea(s)
-    assert 6 == bb.Details().max_nomark  # seat*2, sea*2, tea
+    assert bb.parse_board("s e p e a u h t c")
+    score = bb.upper_bound(BIGINT)
+    assert 4 == bb.details().sum_union  # sea(t), tea(s)
+    assert 6 == bb.details().max_nomark  # seat*2, sea*2, tea
     assert 1 + 1 + 1 + 1 == score  # all words
-    assert 4 == bb.UpperBound(BIGINT)
+    assert 4 == bb.upper_bound(BIGINT)
 
     # a board where both [st]ea can be found, but not simultaneously
     # st z z
     #  e a s
-    assert bb.ParseBoard("st z z e a s z z z")
-    score = bb.UpperBound(BIGINT)
-    assert 3 == bb.Details().sum_union  # tea(s) + sea
-    assert 2 == bb.Details().max_nomark  # tea(s)
+    assert bb.parse_board("st z z e a s z z z")
+    score = bb.upper_bound(BIGINT)
+    assert 3 == bb.details().sum_union  # tea(s) + sea
+    assert 2 == bb.details().max_nomark  # tea(s)
     assert 2 == score
-    assert 2 == bb.UpperBound(BIGINT)
+    assert 2 == bb.upper_bound(BIGINT)
 
     # Add in a "seat", test its (sum union's) shortcomings. Can't have 'seats'
     # and 'teas' on the board simultaneously, but it still counts both.
     # st z z
     #  e a st
     #  z z s
-    assert bb.ParseBoard("st z z e a st z z s")
+    assert bb.parse_board("st z z e a st z z s")
 
-    score = bb.UpperBound(BIGINT)
-    assert 2 + 4 == bb.Details().sum_union  # all but "hiccup"
-    assert 4 == bb.Details().max_nomark  # sea(t(s))
+    score = bb.upper_bound(BIGINT)
+    assert 2 + 4 == bb.details().sum_union  # all but "hiccup"
+    assert 4 == bb.details().max_nomark  # sea(t(s))
     assert 4 == score
 
 
@@ -91,20 +91,20 @@ def test_q(Boggler, TrieT):
     # q a s
     # a e z
     # s t z
-    assert bb.ParseBoard("q a s a e z s t z")
-    score = bb.UpperBound(BIGINT)
-    assert 4 == bb.Details().sum_union
-    assert 6 == bb.Details().max_nomark  # (qa + qas)*2 + qest
+    assert bb.parse_board("q a s a e z s t z")
+    score = bb.upper_bound(BIGINT)
+    assert 4 == bb.details().sum_union
+    assert 6 == bb.details().max_nomark  # (qa + qas)*2 + qest
     assert 4 == score
 
     # Make sure "qu" gets parsed as "either 'qu' or 'u'"
     # qu a s
     # a e z
     # s t z
-    assert bb.ParseBoard("qu a s a e z s t z")
-    score = bb.UpperBound(BIGINT)
-    assert 4 == bb.Details().sum_union
-    assert 6 == bb.Details().max_nomark  # (qa + qas)*2 + qest
+    assert bb.parse_board("qu a s a e z s t z")
+    score = bb.upper_bound(BIGINT)
+    assert 4 == bb.details().sum_union
+    assert 6 == bb.details().max_nomark  # (qa + qas)*2 + qest
     assert 4 == score
 
 
@@ -124,19 +124,19 @@ def test_tar_tier(Boggler, TrieT):
     #  t i z
     # ae z z
     #  r z z
-    assert bb.ParseBoard("t i z ae z z r z z")
-    assert 3 == bb.UpperBound(BIGINT)
-    assert 3 == bb.Details().sum_union
-    assert 3 == bb.Details().max_nomark
-    assert 2 == bb.NumReps()
+    assert bb.parse_board("t i z ae z z r z z")
+    assert 3 == bb.upper_bound(BIGINT)
+    assert 3 == bb.details().sum_union
+    assert 3 == bb.details().max_nomark
+    assert 2 == bb.num_reps()
 
     #  t h .
     #  h e .
     #  . . .
-    assert bb.ParseBoard("t h . h e . . . .")
-    assert 1 == bb.UpperBound(BIGINT)
-    assert 1 == bb.Details().sum_union
-    assert 2 == bb.Details().max_nomark
+    assert bb.parse_board("t h . h e . . . .")
+    assert 1 == bb.upper_bound(BIGINT)
+    assert 1 == bb.details().sum_union
+    assert 2 == bb.details().max_nomark
     assert bb.as_string() == "t h . h e . . . ."
 
 
@@ -158,18 +158,18 @@ def test_bucket_boggle34():
     t = Trie.create_from_file("wordlists/enable2k.txt")
     bb = BucketBoggler34(t)
     # s l p i a e n t r d e s
-    assert bb.ParseBoard(
+    assert bb.parse_board(
         "lnrsy lnrsy chkmpt aeiou aeiou aeiou lnrsy chkmpt lnrsy bdfgjvwxz aeiou lnrsy"
     )
-    assert bb.UpperBound(BIGINT) > 1600
-    d = bb.Details()
+    assert bb.upper_bound(BIGINT) > 1600
+    d = bb.details()
     print(d.max_nomark, d.sum_union)
     assert d.max_nomark == 57_158
     assert d.sum_union == 353_018
 
-    assert bb.ParseBoard("s i n d l a t e p e r s")
-    assert bb.UpperBound(BIGINT) > 1600
-    d = bb.Details()
+    assert bb.parse_board("s i n d l a t e p e r s")
+    assert bb.upper_bound(BIGINT) > 1600
+    d = bb.details()
     print(d.max_nomark, d.sum_union)
     assert d.max_nomark == 1847
     assert d.sum_union == 1651

--- a/boggle/ibuckets_test.py
+++ b/boggle/ibuckets_test.py
@@ -33,11 +33,11 @@ def test_boards(Boggler: type[PyBucketBoggler], TrieT: type[PyTrie]):
 @pytest.mark.parametrize("Boggler, TrieT", PARAMS)
 def test_bound(Boggler: type[PyBucketBoggler], TrieT: type[PyTrie]):
     t = TrieT()
-    t.AddWord("sea")
-    t.AddWord("seat")
-    t.AddWord("seats")
-    t.AddWord("tea")
-    t.AddWord("teas")
+    t.add_word("sea")
+    t.add_word("seat")
+    t.add_word("seats")
+    t.add_word("tea")
+    t.add_word("teas")
 
     bb = Boggler(t, (3, 3))
 
@@ -82,9 +82,9 @@ def test_bound(Boggler: type[PyBucketBoggler], TrieT: type[PyTrie]):
 @pytest.mark.parametrize("Boggler, TrieT", PARAMS)
 def test_q(Boggler, TrieT):
     t = TrieT()
-    t.AddWord("qa")  # qua = 1
-    t.AddWord("qas")  # qua = 1
-    t.AddWord("qest")  # quest = 2
+    t.add_word("qa")  # qua = 1
+    t.add_word("qas")  # qua = 1
+    t.add_word("qest")  # quest = 2
 
     bb = Boggler(t, (3, 3))
 
@@ -113,11 +113,11 @@ def test_tar_tier(Boggler, TrieT):
     # https://www.danvk.org/wp/2009-08-11/a-few-more-boggle-examples/
 
     t = TrieT()
-    t.AddWord("tar")
-    t.AddWord("tie")
-    t.AddWord("tier")
-    t.AddWord("tea")
-    t.AddWord("the")
+    t.add_word("tar")
+    t.add_word("tie")
+    t.add_word("tier")
+    t.add_word("tea")
+    t.add_word("the")
 
     bb = Boggler(t, (3, 3))
 
@@ -143,11 +143,11 @@ def test_tar_tier(Boggler, TrieT):
 def test_tar_tier_boggler():
     # Analogous to test_tar_tier(), but try each board.
     t = PyTrie()
-    t.AddWord("tar")
-    t.AddWord("tie")
-    t.AddWord("tier")
-    t.AddWord("tea")
-    t.AddWord("the")
+    t.add_word("tar")
+    t.add_word("tie")
+    t.add_word("tier")
+    t.add_word("tea")
+    t.add_word("the")
 
     b = PyBoggler(t, (4, 4))
     assert b.score("tizzazzzrzzzzzzz") == 1
@@ -155,7 +155,7 @@ def test_tar_tier_boggler():
 
 
 def test_bucket_boggle34():
-    t = Trie.CreateFromFile("wordlists/enable2k.txt")
+    t = Trie.create_from_file("wordlists/enable2k.txt")
     bb = BucketBoggler34(t)
     # s l p i a e n t r d e s
     assert bb.ParseBoard(

--- a/boggle/make_dot.py
+++ b/boggle/make_dot.py
@@ -127,7 +127,7 @@ def main():
     dims = LEN_TO_DIMS[len(cells)]
     etb = OrderlyTreeBuilder(trie, dims)
     etb.parse_board(board)
-    t = etb.BuildTree()  # dedupe=False)
+    t = etb.build_tree()  # dedupe=False)
     # assert_invariants(t, cells)
     # dedupe_subtrees(t)
 

--- a/boggle/make_dot.py
+++ b/boggle/make_dot.py
@@ -126,7 +126,7 @@ def main():
     cells = board.split(" ")
     dims = LEN_TO_DIMS[len(cells)]
     etb = OrderlyTreeBuilder(trie, dims)
-    etb.ParseBoard(board)
+    etb.parse_board(board)
     t = etb.BuildTree()  # dedupe=False)
     # assert_invariants(t, cells)
     # dedupe_subtrees(t)

--- a/boggle/neighbor_search.py
+++ b/boggle/neighbor_search.py
@@ -17,7 +17,7 @@ def main():
     (base_board,) = sys.argv[1:]
     assert len(base_board) == 16
 
-    t = Trie.CreateFromFile("wordlists/enable2k.txt")
+    t = Trie.create_from_file("wordlists/enable2k.txt")
     assert t
     boggler = Boggler(t)
 

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -208,14 +208,14 @@ def main():
     dims = LEN_TO_DIMS[len(cells)]
     trie = get_trie_from_args(args)
     # etb = TreeBuilder(trie, dims)
-    # assert etb.ParseBoard(board)
+    # assert etb.parse_board(board)
     # e_arena = etb.create_arena()
     # classic_tree = etb.BuildTree(e_arena, dedupe=True)
 
     builder = OrderlyTreeBuilder if args.python else cpp_orderly_tree_builder
     otb = builder(trie, dims)
     o_arena = otb.create_arena()
-    assert otb.ParseBoard(board)
+    assert otb.parse_board(board)
     arenas = []
     arenas.append(o_arena)
     start_s = time.time()

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -61,13 +61,13 @@ class OrderlyTreeBuilder(BoardClassBoggler):
 
         self.trie_.reset_marks()
         for cell in range(len(self.bd_)):
-            self.DoAllDescents(cell, 0, self.trie_, choices, arena)
+            self.do_all_descents(cell, 0, self.trie_, choices, arena)
         self.root = None
         self.trie_.reset_marks()
         assert self.letter_counts == [0] * 26
         return root
 
-    def DoAllDescents(
+    def do_all_descents(
         self, cell: int, length: int, t: PyTrie, choices: list[int], arena
     ):
         choices.append((cell, 0))
@@ -81,7 +81,7 @@ class OrderlyTreeBuilder(BoardClassBoggler):
                 self.letter_counts[cc] += 1
                 if old_count == 1:
                     self.dupe_mask |= 1 << cc
-                self.DoDFS(
+                self.do_dfs(
                     cell,
                     length + (2 if cc == LETTER_Q else 1),
                     t.descend(cc),
@@ -92,7 +92,7 @@ class OrderlyTreeBuilder(BoardClassBoggler):
                 self.dupe_mask = old_mask
         choices.pop()
 
-    def DoDFS(
+    def do_dfs(
         self,
         cell: int,
         length: int,
@@ -105,7 +105,7 @@ class OrderlyTreeBuilder(BoardClassBoggler):
 
         for idx in self.neighbors[cell]:
             if not self.used_ & (1 << idx):
-                self.DoAllDescents(idx, length, t, choices, arena)
+                self.do_all_descents(idx, length, t, choices, arena)
 
         if t.is_word():
             word_score = SCORES[length]

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -39,7 +39,7 @@ class OrderlyTreeBuilder(BoardClassBoggler):
         self.letter_counts = [0] * 26
         self.dupe_mask = 0
 
-    def BuildTree(self, arena: PyArena = None):
+    def build_tree(self, arena: PyArena = None):
         root = SumNode()
         root.letter = ROOT_NODE
         root.points = 0
@@ -66,10 +66,6 @@ class OrderlyTreeBuilder(BoardClassBoggler):
         self.trie_.reset_marks()
         assert self.letter_counts == [0] * 26
         return root
-
-    def SumUnion(self):
-        # This _could_ be computed if there were a need.
-        return 0
 
     def DoAllDescents(
         self, cell: int, length: int, t: PyTrie, choices: list[int], arena
@@ -210,7 +206,7 @@ def main():
     # etb = TreeBuilder(trie, dims)
     # assert etb.parse_board(board)
     # e_arena = etb.create_arena()
-    # classic_tree = etb.BuildTree(e_arena, dedupe=True)
+    # classic_tree = etb.build_tree(e_arena, dedupe=True)
 
     builder = OrderlyTreeBuilder if args.python else cpp_orderly_tree_builder
     otb = builder(trie, dims)
@@ -219,7 +215,7 @@ def main():
     arenas = []
     arenas.append(o_arena)
     start_s = time.time()
-    orderly_tree = otb.BuildTree(o_arena)
+    orderly_tree = otb.build_tree(o_arena)
     elapsed_s = time.time() - start_s
 
     # print("EvalTreeBuilder:    ", end="")

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -59,11 +59,11 @@ class OrderlyTreeBuilder(BoardClassBoggler):
         if arena:
             arena.add_node(root)
 
-        self.trie_.ResetMarks()
+        self.trie_.reset_marks()
         for cell in range(len(self.bd_)):
             self.DoAllDescents(cell, 0, self.trie_, choices, arena)
         self.root = None
-        self.trie_.ResetMarks()
+        self.trie_.reset_marks()
         assert self.letter_counts == [0] * 26
         return root
 
@@ -78,7 +78,7 @@ class OrderlyTreeBuilder(BoardClassBoggler):
         old_mask = self.dupe_mask
         for j, char in enumerate(self.bd_[cell]):
             cc = ord(char) - LETTER_A
-            if t.StartsWord(cc):
+            if t.starts_word(cc):
                 cell_order = self.cell_to_order[cell]
                 choices[cell_order] = j
                 old_count = self.letter_counts[cc]
@@ -88,7 +88,7 @@ class OrderlyTreeBuilder(BoardClassBoggler):
                 self.DoDFS(
                     cell,
                     length + (2 if cc == LETTER_Q else 1),
-                    t.Descend(cc),
+                    t.descend(cc),
                     choices,
                     arena,
                 )
@@ -111,7 +111,7 @@ class OrderlyTreeBuilder(BoardClassBoggler):
             if not self.used_ & (1 << idx):
                 self.DoAllDescents(idx, length, t, choices, arena)
 
-        if t.IsWord():
+        if t.is_word():
             word_score = SCORES[length]
             is_dupe = self.dupe_mask > 0 and self.check_for_dupe(t, choices)
 
@@ -149,9 +149,9 @@ class OrderlyTreeBuilder(BoardClassBoggler):
             return False
 
         this_mark = (self.used_ordered_ << self.shift) + choice_mark
-        prev_paths: set[int] | 0 = t.Mark()
+        prev_paths: set[int] | 0 = t.mark()
         if not prev_paths:
-            t.SetMark({this_mark})
+            t.set_mark({this_mark})
             return False
 
         if this_mark in prev_paths:

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -47,7 +47,7 @@ def test_build_orderly_tree(TrieT, TreeBuilderT):
     board = "s e p e a u h t c"
     cells = board.split(" ")
     assert bb.parse_board(board)
-    t = bb.BuildTree(arena)
+    t = bb.build_tree(arena)
     if isinstance(t, SumNode):
         t.assert_invariants(bb)
     assert outsource(eval_node_to_string(t, cells)) == snapshot(
@@ -80,7 +80,7 @@ def test_lift_invariants_33(make_trie, get_tree_builder):
     otb = get_tree_builder(trie, dims=(3, 3))
     otb.parse_board(board)
     arena = otb.create_arena()
-    t = otb.BuildTree(arena)
+    t = otb.build_tree(arena)
     if isinstance(t, SumNode):
         t.assert_invariants(otb)
 
@@ -97,7 +97,7 @@ def test_orderly_bound22(is_python):
     # num_letters = [len(cell) for cell in cells]
     otb.parse_board(board)
     arena = otb.create_arena()
-    t = otb.BuildTree(arena)
+    t = otb.build_tree(arena)
     if isinstance(t, SumNode):
         t.assert_invariants(otb)
     assert t.bound == 8
@@ -115,7 +115,7 @@ def test_orderly_bound22_best(make_trie, get_tree_builder):
     otb = get_tree_builder(trie, dims=(2, 2))
     otb.parse_board(board)
     arena = otb.create_arena()
-    t = otb.BuildTree(arena)
+    t = otb.build_tree(arena)
     if isinstance(t, SumNode):
         t.assert_invariants(otb)
     assert t.bound == snapshot(21)
@@ -146,7 +146,7 @@ def test_orderly_merge():
     num_letters = [len(cell) for cell in cells]
     otb.parse_board(board)
     arena = otb.create_arena()
-    t = otb.BuildTree(arena)
+    t = otb.build_tree(arena)
     split_order = SPLIT_ORDER[(2, 2)]
     if isinstance(t, SumNode):
         t.assert_invariants(otb)
@@ -197,7 +197,7 @@ def test_orderly_force22(is_python):
     num_letters = [len(cell) for cell in cells]
     otb.parse_board(board)
     arena = otb.create_arena()
-    t = otb.BuildTree(arena)
+    t = otb.build_tree(arena)
     force = t.orderly_force_cell(0, num_letters[0], arena)
 
     txt = "\n\n".join(
@@ -216,7 +216,7 @@ def test_orderly_bound33(make_trie, get_tree_builder):
     otb = get_tree_builder(trie, dims=(3, 3))
     otb.parse_board(board)
     arena = otb.create_arena()
-    t = otb.BuildTree(arena)
+    t = otb.build_tree(arena)
     if isinstance(t, SumNode):
         t.assert_invariants(otb)
         print(otb.cell_counts)
@@ -241,7 +241,7 @@ def test_force_invariants22(is_python):
     num_letters = [len(cell) for cell in cells]
     otb.parse_board(board)
     arena = otb.create_arena()
-    root = otb.BuildTree(arena)
+    root = otb.build_tree(arena)
     # print(t.to_dot(cells))
 
     scores = eval_all(root, cells)
@@ -319,7 +319,7 @@ def test_build_invariants44():
 
     arena = otb.create_arena()
     assert otb.parse_board(board)
-    root = otb.BuildTree(arena)
+    root = otb.build_tree(arena)
     assert root.bound == snapshot(3858)
 
     # the orderly bound is only a bit better for this board thanks to all the repeat "e"s.
@@ -354,7 +354,7 @@ def test_force_invariants44():
 
     arena = otb.create_arena()
     assert otb.parse_board(base_board)
-    root = otb.BuildTree(arena)
+    root = otb.build_tree(arena)
     assert root.bound == snapshot(15051)
 
     forces = [
@@ -387,7 +387,7 @@ def test_force_invariants44():
     board = " ".join(cells)
     cells = board.split(" ")
     assert otb.parse_board(board)
-    direct_root = otb.BuildTree(arena)
+    direct_root = otb.build_tree(arena)
 
     # The direct tree's bound is much higher because the cells with single letters
     # interfere with the other choices and desynchronize them. Despite this, it _is_
@@ -437,7 +437,7 @@ def test_missing_top_choice():
     base_num_letters = [len(cell) for cell in base_cells]
     arena = otb.create_arena()
     assert otb.parse_board(" ".join(base_cells))
-    root = otb.BuildTree(arena)
+    root = otb.build_tree(arena)
     assert root.bound == snapshot(21049)
 
     forces = [

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -32,11 +32,11 @@ from boggle.trie import PyTrie, make_py_trie
 )
 def test_build_orderly_tree(TrieT, TreeBuilderT):
     t = TrieT()
-    t.AddWord("sea")
-    t.AddWord("seat")
-    t.AddWord("seats")
-    t.AddWord("tea")
-    t.AddWord("teas")
+    t.add_word("sea")
+    t.add_word("seat")
+    t.add_word("seats")
+    t.add_word("tea")
+    t.add_word("teas")
 
     bb = TreeBuilderT(t, (3, 3))
     arena = bb.create_arena()
@@ -57,7 +57,7 @@ def test_build_orderly_tree(TrieT, TreeBuilderT):
 
 OTB_PARAMS = [
     (make_py_trie, OrderlyTreeBuilder),
-    (Trie.CreateFromFile, cpp_orderly_tree_builder),
+    (Trie.create_from_file, cpp_orderly_tree_builder),
 ]
 
 
@@ -66,7 +66,7 @@ def get_trie_otb(dict_file: str, dims: tuple[int, int], is_python: bool):
         trie = make_py_trie(dict_file)
         otb = OrderlyTreeBuilder(trie, dims=dims)
     else:
-        trie = Trie.CreateFromFile(dict_file)
+        trie = Trie.create_from_file(dict_file)
         otb = cpp_orderly_tree_builder(trie, dims=dims)
     return trie, otb
 

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -46,7 +46,7 @@ def test_build_orderly_tree(TrieT, TreeBuilderT):
     # p u c
     board = "s e p e a u h t c"
     cells = board.split(" ")
-    assert bb.ParseBoard(board)
+    assert bb.parse_board(board)
     t = bb.BuildTree(arena)
     if isinstance(t, SumNode):
         t.assert_invariants(bb)
@@ -78,7 +78,7 @@ def test_lift_invariants_33(make_trie, get_tree_builder):
     # board = ". . . . nr e ai au ."
     cells = board.split(" ")
     otb = get_tree_builder(trie, dims=(3, 3))
-    otb.ParseBoard(board)
+    otb.parse_board(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
     if isinstance(t, SumNode):
@@ -95,7 +95,7 @@ def test_orderly_bound22(is_python):
     board = "ab cd ef gh"
     cells = board.split(" ")
     # num_letters = [len(cell) for cell in cells]
-    otb.ParseBoard(board)
+    otb.parse_board(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
     if isinstance(t, SumNode):
@@ -113,7 +113,7 @@ def test_orderly_bound22_best(make_trie, get_tree_builder):
     cells = board.split(" ")
     # num_letters = [len(cell) for cell in cells]
     otb = get_tree_builder(trie, dims=(2, 2))
-    otb.ParseBoard(board)
+    otb.parse_board(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
     if isinstance(t, SumNode):
@@ -144,7 +144,7 @@ def test_orderly_merge():
     board = "st ea ea tr"
     cells = board.split(" ")
     num_letters = [len(cell) for cell in cells]
-    otb.ParseBoard(board)
+    otb.parse_board(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
     split_order = SPLIT_ORDER[(2, 2)]
@@ -195,7 +195,7 @@ def test_orderly_force22(is_python):
     board = "st ea ea tr"
     cells = board.split(" ")
     num_letters = [len(cell) for cell in cells]
-    otb.ParseBoard(board)
+    otb.parse_board(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
     force = t.orderly_force_cell(0, num_letters[0], arena)
@@ -214,7 +214,7 @@ def test_orderly_bound33(make_trie, get_tree_builder):
     board = "lnrsy chkmpt lnrsy aeiou lnrsy aeiou bdfgjvwxz lnrsy chkmpt"
     cells = board.split(" ")
     otb = get_tree_builder(trie, dims=(3, 3))
-    otb.ParseBoard(board)
+    otb.parse_board(board)
     arena = otb.create_arena()
     t = otb.BuildTree(arena)
     if isinstance(t, SumNode):
@@ -239,7 +239,7 @@ def test_force_invariants22(is_python):
     board = "lnrsy aeiou chkmpt bdfgjvwxz"
     cells = board.split(" ")
     num_letters = [len(cell) for cell in cells]
-    otb.ParseBoard(board)
+    otb.parse_board(board)
     arena = otb.create_arena()
     root = otb.BuildTree(arena)
     # print(t.to_dot(cells))
@@ -293,9 +293,9 @@ def test_force_invariants22(is_python):
     for idx in itertools.product(*(range(len(cell)) for cell in cells)):
         i0, i1, i2, i3 = idx
         bd = " ".join(cells[i][letter] for i, letter in enumerate(idx))
-        assert ibb.ParseBoard(bd)
-        ibb.UpperBound(123)
-        score = ibb.Details().max_nomark
+        assert ibb.parse_board(bd)
+        ibb.upper_bound(123)
+        score = ibb.details().max_nomark
         # print(idx, bd, score)
         assert score == all_scores[0][idx]
         assert score == all_scores[1][idx]
@@ -318,15 +318,15 @@ def test_build_invariants44():
     cells = board.split(" ")
 
     arena = otb.create_arena()
-    assert otb.ParseBoard(board)
+    assert otb.parse_board(board)
     root = otb.BuildTree(arena)
     assert root.bound == snapshot(3858)
 
     # the orderly bound is only a bit better for this board thanks to all the repeat "e"s.
     ibb = cpp_bucket_boggler(trie, dims)
-    assert ibb.ParseBoard(board)
-    ibb.UpperBound(123_456)
-    ibuckets_score = ibb.Details().max_nomark
+    assert ibb.parse_board(board)
+    ibb.upper_bound(123_456)
+    ibuckets_score = ibb.details().max_nomark
     assert ibuckets_score == snapshot(4348)
 
     scores = eval_all(root, cells)
@@ -353,7 +353,7 @@ def test_force_invariants44():
     base_num_letters = [len(cell) for cell in base_cells]
 
     arena = otb.create_arena()
-    assert otb.ParseBoard(base_board)
+    assert otb.parse_board(base_board)
     root = otb.BuildTree(arena)
     assert root.bound == snapshot(15051)
 
@@ -386,7 +386,7 @@ def test_force_invariants44():
 
     board = " ".join(cells)
     cells = board.split(" ")
-    assert otb.ParseBoard(board)
+    assert otb.parse_board(board)
     direct_root = otb.BuildTree(arena)
 
     # The direct tree's bound is much higher because the cells with single letters
@@ -436,7 +436,7 @@ def test_missing_top_choice():
     ]
     base_num_letters = [len(cell) for cell in base_cells]
     arena = otb.create_arena()
-    assert otb.ParseBoard(" ".join(base_cells))
+    assert otb.parse_board(" ".join(base_cells))
     root = otb.BuildTree(arena)
     assert root.bound == snapshot(21049)
 

--- a/boggle/subboard_search.py
+++ b/boggle/subboard_search.py
@@ -20,7 +20,7 @@ def main():
     (board3,) = sys.argv[1:]
     assert len(board3) == 12
 
-    t = Trie.CreateFromFile("wordlists/enable2k.txt")
+    t = Trie.create_from_file("wordlists/enable2k.txt")
     assert t
     boggler = Boggler(t)
 

--- a/boggle/trie.py
+++ b/boggle/trie.py
@@ -4,74 +4,78 @@ LETTER_A = ord("a")
 
 
 class PyTrie:
+    _children: list[Self | None]
+    _mark: int
+    _is_word: bool
+
     def __init__(self):
-        self.is_word = False
-        self.mark = 0
-        self.children = [None] * 26
+        self._is_word = False
+        self._mark = 0
+        self._children = [None] * 26
 
-    def StartsWord(self, i: int):
-        return self.children[i] is not None
+    def starts_word(self, i: int):
+        return self._children[i] is not None
 
-    def Descend(self, i: int):
-        return self.children[i]
+    def descend(self, i: int):
+        return self._children[i]
 
-    def IsWord(self):
-        return self.is_word
+    def is_word(self):
+        return self._is_word
 
-    def Mark(self):
-        return self.mark
+    def mark(self):
+        return self._mark
 
-    def SetMark(self, mark):
-        self.mark = mark
+    def set_mark(self, mark):
+        self._mark = mark
 
     # ---
 
-    def SetIsWord(self):
-        self.is_word = True
+    def set_is_word(self):
+        self._is_word = True
 
-    def AddWord(self, word):
+    def add_word(self, word: str) -> Self:
         if word == "":
-            self.SetIsWord()
+            self.set_is_word()
             return self
         c = ord(word[0]) - LETTER_A
         try:
-            if not self.StartsWord(c):
-                self.children[c] = PyTrie()
+            if not self.starts_word(c):
+                self._children[c] = PyTrie()
         except IndexError:
             print(c, word)
             raise
-        return self.Descend(c).AddWord(word[1:])
+        return self.descend(c).add_word(word[1:])
 
-    def Size(self):
-        return (1 if self.IsWord() else 0) + sum(c.Size() for c in self.children if c)
+    def size(self):
+        return (1 if self.is_word() else 0) + sum(c.size() for c in self._children if c)
 
-    def NumNodes(self):
-        return 1 + sum(c.NumNodes() for c in self.children if c)
+    def num_nodes(self):
+        return 1 + sum(c.num_nodes() for c in self._children if c)
 
-    def FindWord(self, word):
+    def find_word(self, word: str):
         if word == "":
             return self
         c = ord(word[0]) - LETTER_A
-        if self.StartsWord(c):
-            return self.Descend(c).FindWord(word[1:])
+        if self.starts_word(c):
+            return self.descend(c).find_word(word[1:])
         return None
 
-    def ResetMarks(self):
-        self.mark = 0
-        for child in self.children:
+    def reset_marks(self):
+        self.set_mark(0)
+        for child in self._children:
             if not child:
                 continue
-            child.ResetMarks()
+            child.reset_marks()
 
     @staticmethod
-    def ReverseLookup(root: Self, node: Self):
+    def reverse_lookup(root: Self, node: Self):
         return reverse_lookup(root, node)
 
 
 def reverse_lookup(root: PyTrie, node: PyTrie):
     if root is node:
         return ""
-    for i, child in enumerate(root.children):
+    for i, child in enumerate(root._children):
         if not child:
             continue
         child_result = reverse_lookup(child, node)
@@ -84,7 +88,7 @@ def make_lookup_table(t: PyTrie, prefix="", out=None) -> dict[PyTrie, str]:
     """Construct a Trie -> str table for debugging."""
     out = out or {}
     out[t] = prefix
-    for i, child in enumerate(t.children):
+    for i, child in enumerate(t._children):
         if child:
             make_lookup_table(child, prefix + chr(i + LETTER_A), out)
     return out
@@ -115,5 +119,5 @@ def make_py_trie(dict_input: str):
         word = word.strip()
         word = bogglify_word(word)
         if word is not None:
-            t.AddWord(word)
+            t.add_word(word)
     return t

--- a/boggle/trie_test.py
+++ b/boggle/trie_test.py
@@ -10,39 +10,39 @@ def asc(char: str):
 
 def test_trie():
     t = Trie()
-    t.AddWord("agriculture")
-    t.AddWord("culture")
-    t.AddWord("boggle")
-    t.AddWord("tea")
-    t.AddWord("sea")
-    t.AddWord("teapot")
-    assert not t.IsWord()
+    t.add_word("agriculture")
+    t.add_word("culture")
+    t.add_word("boggle")
+    t.add_word("tea")
+    t.add_word("sea")
+    t.add_word("teapot")
+    assert not t.is_word()
 
-    assert t.Size() == 6
-    assert t.FindWord("agriculture") is not None
-    assert t.FindWord("culture") is not None
-    assert t.FindWord("boggle") is not None
-    assert t.FindWord("tea") is not None
-    assert t.FindWord("sea") is not None
-    assert t.FindWord("teapot") is not None
+    assert t.size() == 6
+    assert t.find_word("agriculture") is not None
+    assert t.find_word("culture") is not None
+    assert t.find_word("boggle") is not None
+    assert t.find_word("tea") is not None
+    assert t.find_word("sea") is not None
+    assert t.find_word("teapot") is not None
 
-    assert t.FindWord("teap") is None
-    assert t.FindWord("random") is None
-    assert t.FindWord("cultur") is None
+    assert t.find_word("teap") is None
+    assert t.find_word("random") is None
+    assert t.find_word("cultur") is None
 
-    wd = t.Descend(asc("t"))
+    wd = t.descend(asc("t"))
     assert wd is not None
-    wd = wd.Descend(asc("e"))
+    wd = wd.descend(asc("e"))
     assert wd is not None
-    wd = wd.Descend(asc("a"))
+    wd = wd.descend(asc("a"))
     assert wd is not None
-    assert wd.Mark() == 0
-    wd.SetMark(12345)
-    assert wd.Mark() == 12345
+    assert wd.mark() == 0
+    wd.set_mark(12345)
+    assert wd.mark() == 12345
 
-    child = t.FindWord("agriculture")
+    child = t.find_word("agriculture")
     assert child is not None
-    assert Trie.ReverseLookup(t, child) == "agriculture"
+    assert Trie.reverse_lookup(t, child) == "agriculture"
 
 
 def test_bogglify_word():
@@ -54,8 +54,8 @@ def test_bogglify_word():
 
 
 def test_load_file():
-    t = Trie.CreateFromFile("testdata/boggle-words-4.txt")
-    assert not t.IsWord()
+    t = Trie.create_from_file("testdata/boggle-words-4.txt")
+    assert not t.is_word()
 
-    assert t.FindWord("wood") is not None
-    assert t.FindWord("woxd") is None
+    assert t.find_word("wood") is not None
+    assert t.find_word("woxd") is None

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -34,16 +34,15 @@ void declare_tree_builder(py::module &m, const string &pyclass_name) {
   py::class_<TB>(m, pyclass_name.c_str(), py::buffer_protocol())
       .def(py::init<Trie *>())
       .def(
-          "BuildTree",
+          "build_tree",
           &TB::BuildTree,
           py::return_value_policy::reference,
           py::arg("arena"),
           py::arg("dedupe") = false
       )
-      .def("ParseBoard", &TB::ParseBoard)
+      .def("parse_board", &TB::ParseBoard)
       .def("as_string", &TB::as_string)
-      .def("SumUnion", &TB::SumUnion)
-      .def("NumReps", &TB::NumReps)
+      .def("num_reps", &TB::NumReps)
       .def("create_arena", &TB::CreateArena);
 }
 

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -21,11 +21,11 @@ void declare_bucket_boggler(py::module &m, const string &pyclass_name) {
   // TODO: do I care about buffer_protocol() here?
   py::class_<BB>(m, pyclass_name.c_str(), py::buffer_protocol())
       .def(py::init<Trie *>())
-      .def("ParseBoard", &BB::ParseBoard)
-      .def("UpperBound", &BB::UpperBound)
+      .def("parse_board", &BB::ParseBoard)
+      .def("upper_bound", &BB::UpperBound)
       .def("as_string", &BB::as_string)
-      .def("Details", &BB::Details)
-      .def("NumReps", &BB::NumReps);
+      .def("details", &BB::Details)
+      .def("num_reps", &BB::NumReps);
 }
 
 template <typename TB>

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -65,24 +65,24 @@ PYBIND11_MODULE(cpp_boggle, m) {
   // TODO: add docstrings for all methods
   py::class_<Trie>(m, "Trie")
       .def(py::init())
-      .def("StartsWord", &Trie::StartsWord)
-      .def("Descend", &Trie::Descend, py::return_value_policy::reference)
-      .def("IsWord", &Trie::IsWord)
-      .def("Mark", py::overload_cast<>(&Trie::Mark))
-      .def("SetMark", py::overload_cast<uintptr_t>(&Trie::Mark))
+      .def("starts_word", &Trie::StartsWord)
+      .def("descend", &Trie::Descend, py::return_value_policy::reference)
+      .def("is_word", &Trie::IsWord)
+      .def("mark", py::overload_cast<>(&Trie::Mark))
+      .def("set_mark", py::overload_cast<uintptr_t>(&Trie::Mark))
       // Possible that these should be ::reference_internal instead. See
       // https://pybind11.readthedocs.io/en/stable/advanced/functions.html#return-value-policies
-      .def("AddWord", &Trie::AddWord, py::return_value_policy::reference)
-      .def("FindWord", &Trie::FindWord, py::return_value_policy::reference)
-      .def("Size", &Trie::Size)
-      .def("NumNodes", &Trie::NumNodes)
-      .def("ResetMarks", &Trie::ResetMarks)
-      .def("SetAllMarks", &Trie::SetAllMarks)
+      .def("add_word", &Trie::AddWord, py::return_value_policy::reference)
+      .def("find_word", &Trie::FindWord, py::return_value_policy::reference)
+      .def("size", &Trie::Size)
+      .def("num_nodes", &Trie::NumNodes)
+      .def("reset_marks", &Trie::ResetMarks)
+      .def("set_all_marks", &Trie::SetAllMarks)
       .def_static(
-          "ReverseLookup",
+          "reverse_lookup",
           py::overload_cast<const Trie *, const Trie *>(&Trie::ReverseLookup)
       )
-      .def_static("CreateFromFile", &Trie::CreateFromFile);
+      .def_static("create_from_file", &Trie::CreateFromFile);
 
   declare_boggler<2, 2>(m, "Boggler22");
   declare_boggler<2, 3>(m, "Boggler23");


### PR DESCRIPTION
Fixes #126 

Use `method_name()` consistently instead of `MethodName()`. Newer code already did this, but this ports the older code over.

