### PR TITLE
Misc cleanup and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Here are the blog posts I've written about this project in 2025:
 - [New Ideas in 2025][post2]: Explains Multi-Boggle, the EvalTree structure and the basic operations on it.
 - [A Thrilling Insight and the Power of Algorithms][post3]: Explains Orderly Trees, the idea that really broke this problem open.
 - [Following up on an insight][post4]: Explains a incremental improvements that brought 4x4 Boggle in range.
+- [After 20 Years, the Globally Optimal Boggle Board][35]: Announcement of the big 4x4 Boggle result.
 
 For earlier posts, check out this [2014 compendium].
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To calculate the upper bound on a board class using 2025's [orderly trees], use 
 
 ```
 $ poetry run python -m boggle.orderly_tree_builder "lnrsy aeiou chkmpt chkmpt aeiou lnrsy lnrsy aeiou bdfgjvwxz"
-0.05s OrderlyTreeBuilder: t.bound=1449, 332438 nodes
+0.05s OrderlyTreeBuilder: t.bound=1231, 332438 nodes
 ```
 
 Note that this bound is considerably lower, but computing it requires more time and memory.
@@ -174,6 +174,7 @@ The image that was used to exhaustively search for the best 4x4 board was [danvk
 If you're trying to follow the code, here are a few pointers that will help:
 
 - The word lists are processed to exclude invalid Boggle words and change "qu" to "q". So "quart" will be inserted in the Trie as "qart". See [wordlists/README.md](wordlists/README.md) for more.
+- There is a convention that the "mark" on the root Trie node tracks the largest mark that's been placed on any node in the Trie. This avoids the need for synchronization across all the different classes that make use of Tries and their marks.
 - Boggle boards are represented as 1-dimensional arrays. So a 4x4 Boggle board is a 16 character string. For 3x4 boards, which are 12 character strings, you need to read down the columns to get the right board.
 - Generally the Python and C++ code match 1-1. I developed code in Python, wrote tests for it, and then translated it to C++ (sometimes with help from GitHub Copilot). The APIs are identical and they pass the same tests. Most CLI tools let you toggle between the C++ and Python implementations with the `--python` flag.
 - Most CLI tools require you to set the size of the Boggle board. 3x3 is the default. If you want 4x4, set `--size 44`.

--- a/boggle/break_all.py
+++ b/boggle/break_all.py
@@ -178,7 +178,7 @@ def get_breaker(args) -> BreakingBundle:
     etb = builder(t, dims)
 
     if args.breaker == "hybrid":
-        switchover_score = args.switchover_score or 2.5 * best_score
+        switchover_score = args.switchover_score or 1.7 * best_score
         breaker = HybridTreeBreaker(
             etb,
             boggler,
@@ -248,7 +248,7 @@ def main():
         default=None,
         help="When to switch from splitting the tree by forcing cells to evaluating the "
         "remaining tree with a DFS. Higher values will use less RAM but potentially run "
-        "more slowly. The default is 2.5 * best_score.",
+        "more slowly. The default is 1.7 * best_score.",
     )
     parser.add_argument(
         "--breaker",

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -35,8 +35,7 @@ void declare_tree_builder(py::module &m, const string &pyclass_name) {
           "build_tree",
           &TB::BuildTree,
           py::return_value_policy::reference,
-          py::arg("arena"),
-          py::arg("dedupe") = false
+          py::arg("arena")
       )
       .def("parse_board", &TB::ParseBoard)
       .def("as_string", &TB::as_string)

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -18,8 +18,7 @@ using std::vector;
 template <int M, int N>
 void declare_bucket_boggler(py::module &m, const string &pyclass_name) {
   using BB = BucketBoggler<M, N>;
-  // TODO: do I care about buffer_protocol() here?
-  py::class_<BB>(m, pyclass_name.c_str(), py::buffer_protocol())
+  py::class_<BB>(m, pyclass_name.c_str())
       .def(py::init<Trie *>())
       .def("parse_board", &BB::ParseBoard)
       .def("upper_bound", &BB::UpperBound)
@@ -30,8 +29,7 @@ void declare_bucket_boggler(py::module &m, const string &pyclass_name) {
 
 template <typename TB>
 void declare_tree_builder(py::module &m, const string &pyclass_name) {
-  // TODO: do I care about buffer_protocol() here?
-  py::class_<TB>(m, pyclass_name.c_str(), py::buffer_protocol())
+  py::class_<TB>(m, pyclass_name.c_str())
       .def(py::init<Trie *>())
       .def(
           "build_tree",
@@ -49,8 +47,7 @@ void declare_tree_builder(py::module &m, const string &pyclass_name) {
 template <int M, int N>
 void declare_boggler(py::module &m, const string &pyclass_name) {
   using BB = Boggler<M, N>;
-  // TODO: do I care about buffer_protocol() here?
-  py::class_<BB>(m, pyclass_name.c_str(), py::buffer_protocol())
+  py::class_<BB>(m, pyclass_name.c_str())
       .def(py::init<Trie *>())
       .def("score", &BB::Score)
       .def("find_words", &BB::FindWords)
@@ -104,7 +101,7 @@ PYBIND11_MODULE(cpp_boggle, m) {
   declare_tree_builder<OrderlyTreeBuilder<4, 4>>(m, "OrderlyTreeBuilder44");
   declare_tree_builder<OrderlyTreeBuilder<5, 5>>(m, "OrderlyTreeBuilder55");
 
-  py::class_<ScoreDetails>(m, "ScoreDetails", py::buffer_protocol())
+  py::class_<ScoreDetails>(m, "ScoreDetails")
       .def_readwrite("max_nomark", &ScoreDetails::max_nomark)
       .def_readwrite("sum_union", &ScoreDetails::sum_union)
       .def_readwrite("bailout_cell", &ScoreDetails::bailout_cell);

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -25,7 +25,7 @@ class OrderlyTreeBuilder : public BoardClassBoggler<M, N> {
   using BoardClassBoggler<M, N>::used_;
 
   /** Build an EvalTree for the current board. */
-  const SumNode* BuildTree(EvalNodeArena& arena, bool dedupe = false);
+  const SumNode* BuildTree(EvalNodeArena& arena);
 
   unique_ptr<EvalNodeArena> CreateArena() { return create_eval_node_arena(); }
 
@@ -50,7 +50,7 @@ class OrderlyTreeBuilder : public BoardClassBoggler<M, N> {
 };
 
 template <int M, int N>
-const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena, bool dedupe) {
+const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena) {
   // auto start = chrono::high_resolution_clock::now();
   // cout << "alignment_of<EvalNode>=" << alignment_of<EvalNode>() << endl;
   root_ = arena.NewRootNodeWithCapacity(M * N);  // this will never be reallocated

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -5,6 +5,7 @@ poetry run python -m boggle.break_all \
     'bdfgjvwxz aeiou lnrsy chkmpt' 1400 \
     --size 34 \
     --board_id 2520743 \
+    --switchover_score 3500 \
     --log_per_board_stats \
     --omit_times \
     > testdata/3x4-2520743-1400.txt


### PR DESCRIPTION
buffer_protocol doesn't seem to have any obvious impact on performance, so my inclination is to drop it.

I've known that the default `--switchover_score` is too high for a while. This defaults to a lower value.

This is a less ambitious version of #128