### PR TITLE
Drop assertion

### DIFF
--- a/cpp/trie.cc
+++ b/cpp/trie.cc
@@ -104,7 +104,6 @@ unique_ptr<Trie> Trie::CreateFromFile(const char* filename) {
   while (!feof(f) && fscanf(f, "%s", line)) {
     if (BogglifyWord(line)) {
       t->AddWord(line)->SetWordId(count++);
-      assert(count <= 262143);
     }
   }
   fclose(f);


### PR DESCRIPTION
This got left in with #120 but it's not relevant. We can use all 32 bits. Some wordlists (SOWPODS, YAWL) have more than 260k entries:

```
$ wc -l wordlists/*.txt
   42625 wordlists/enable2k.jpa14.txt
  173528 wordlists/enable2k.txt
  196601 wordlists/naspa2023.txt
  109928 wordlists/ospd5.txt
  279078 wordlists/sowpods.txt
  178691 wordlists/twl06.txt
  264097 wordlists/yawl.txt
```