### PR TITLE
Dedupe on SumNode, not TrieNode

### DIFF
--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -110,7 +110,7 @@ PYBIND11_MODULE(cpp_boggle, m) {
       .def_property_readonly("bound", &SumNode::Bound)
       .def_readonly("points", &SumNode::points_)
       .def("node_count", &SumNode::NodeCount)
-      .def("add_word", &SumNode::AddWord, py::return_value_policy::reference)
+      // .def("add_word", &SumNode::AddWord, py::return_value_policy::reference)
       .def(
           "orderly_force_cell",
           &SumNode::OrderlyForceCell,

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -641,8 +641,8 @@ vector<const SumNode*> SumNode::OrderlyForceCell(
 }
 
 void SumNode::SetPointsAndBound(vector<vector<uint32_t>>& wordlists) {
-  // decode points
   if (bound_) {
+    // A word was found on this node; decode the points.
     int count;
     if (bound_ & (1 << 23)) {
       // just one word stored inline

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -88,16 +88,16 @@ SumNode* SumNode::AddWordWork(
       break;
     }
   }
-  int old_choice_bound = 0;
+  // int old_choice_bound = 0;
   SumNode* new_me = this;
   if (!choice_child) {
     choice_child = arena.NewChoiceNodeWithCapacity(1);
     choice_child->cell_ = cell;
-    choice_child->bound_ = 0;
+    // choice_child->bound_ = 0;
     new_me = AddChild(choice_child, arena);
     sort(&new_me->children_[0], &new_me->children_[new_me->num_children_], SortByCell);
   } else {
-    old_choice_bound = choice_child->bound_;
+    // old_choice_bound = choice_child->bound_;
   }
 
   // TODO: might be cleaner to call a helper on ChoiceNode here
@@ -113,7 +113,7 @@ SumNode* SumNode::AddWordWork(
     unsigned int num_choices = std::popcount(used_ordered);
     letter_child = arena.NewSumNodeWithCapacity(num_choices == 1 ? 0 : 1);
     letter_child->letter_ = letter;
-    letter_child->bound_ = 0;
+    // letter_child->bound_ = 0;
     auto new_choice_child = choice_child->AddChild(letter_child, arena);
     if (new_choice_child != choice_child) {
       const auto& old_choice_child = choice_child;
@@ -154,10 +154,10 @@ SumNode* SumNode::AddWordWork(
     letter_child = new_letter_child;
   }
 
-  if (letter_child->bound_ > old_choice_bound) {
-    choice_child->bound_ = letter_child->bound_;
-    new_me->bound_ += (choice_child->bound_ - old_choice_bound);
-  }
+  // if (letter_child->bound_ > old_choice_bound) {
+  //   choice_child->bound_ = letter_child->bound_;
+  //   new_me->bound_ += (choice_child->bound_ - old_choice_bound);
+  // }
 
   return new_me;
 }

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -639,3 +639,32 @@ vector<const SumNode*> SumNode::OrderlyForceCell(
   }
   return out;
 }
+
+void SumNode::SetPointsAndBound(vector<vector<uint32_t>>& wordlists) {
+  // decode points
+  if (bound_) {
+    auto slot = (points_ << 24) + bound_;
+    auto& wordlist = wordlists[slot];
+    auto points = wordlist[0];
+    auto count = wordlist.size() - 1;
+    points_ = bound_ = points * count;
+  } else {
+    bound_ = points_;
+  }
+
+  for (int i = 0; i < num_children_; i++) {
+    auto& child = children_[i];
+    child->SetPointsAndBound(wordlists);
+    bound_ += child->bound_;
+  }
+}
+
+void ChoiceNode::SetPointsAndBound(vector<vector<uint32_t>>& wordlists) {
+  uint32_t bound = 0;
+  for (int i = 0; i < num_children_; i++) {
+    auto& child = children_[i];
+    child->SetPointsAndBound(wordlists);
+    bound = max(bound, child->bound_);
+  }
+  bound_ = bound;
+}

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -650,7 +650,7 @@ void SumNode::SetPointsAndBound(vector<vector<uint32_t>>& wordlists) {
     } else {
       auto slot = bound_;
       auto& wordlist = wordlists[slot];
-      count = wordlist.size() - 1;
+      count = wordlist.size();
     }
     auto word_score = points_;
     points_ = bound_ = word_score * count;

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -61,12 +61,13 @@ SumNode* SumNode::AddWordWork(
     int choices[],
     unsigned int used_ordered,
     const int split_order[],
-    int points,
+    SumNode** leaf,
     EvalNodeArena& arena
 ) {
   if (used_ordered == 0) {
-    points_ += points;
-    bound_ += points;
+    // points_ += points;
+    // bound_ += points;
+    *leaf = this;
     return this;
   }
 
@@ -136,7 +137,7 @@ SumNode* SumNode::AddWordWork(
     );
   }
   auto new_letter_child =
-      letter_child->AddWordWork(choices, used_ordered, split_order, points, arena);
+      letter_child->AddWordWork(choices, used_ordered, split_order, leaf, arena);
   if (new_letter_child != letter_child) {
     const auto& old_letter_child = letter_child;
     bool patched = false;
@@ -165,10 +166,10 @@ void SumNode::AddWord(
     vector<int> choices,
     unsigned int used_ordered,
     vector<int> split_order,
-    int points,
+    SumNode** leaf,
     EvalNodeArena& arena
 ) {
-  auto r = AddWordWork(choices.data(), used_ordered, split_order.data(), points, arena);
+  auto r = AddWordWork(choices.data(), used_ordered, split_order.data(), leaf, arena);
   assert(r == this);
 }
 

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -643,11 +643,17 @@ vector<const SumNode*> SumNode::OrderlyForceCell(
 void SumNode::SetPointsAndBound(vector<vector<uint32_t>>& wordlists) {
   // decode points
   if (bound_) {
-    auto slot = (points_ << 24) + bound_;
-    auto& wordlist = wordlists[slot];
-    auto points = wordlist[0];
-    auto count = wordlist.size() - 1;
-    points_ = bound_ = points * count;
+    int count;
+    if (bound_ & (1 << 23)) {
+      // just one word stored inline
+      count = 1;
+    } else {
+      auto slot = bound_;
+      auto& wordlist = wordlists[slot];
+      count = wordlist.size() - 1;
+    }
+    auto word_score = points_;
+    points_ = bound_ = word_score * count;
   } else {
     bound_ = points_;
   }

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -49,6 +49,8 @@ class SumNode {
 
   void PrintJSON() const;
 
+  void SetPointsAndBound(vector<vector<uint32_t>>& wordlists);
+
   // Shallow copy -- excludes children
   void CopyFrom(SumNode& other);
 
@@ -88,6 +90,8 @@ class ChoiceNode {
   SumNode* children_[];
 
   void PrintJSON() const;
+
+  void SetPointsAndBound(vector<vector<uint32_t>>& wordlists);
 
   // Shallow copy -- excludes children
   void CopyFrom(ChoiceNode& other);

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -19,7 +19,7 @@ class EvalNodeArena;
 
 class SumNode {
  public:
-  SumNode() : points_(0), num_children_(0) {}
+  SumNode() : bound_(0), points_(0), num_children_(0) {}
   ~SumNode() {}
 
   void AddWord(

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -26,7 +26,7 @@ class SumNode {
       vector<int> choices,
       unsigned int used_ordered,
       vector<int> split_order,
-      int points,
+      SumNode** leaf,
       EvalNodeArena& arena
   );
 
@@ -34,7 +34,7 @@ class SumNode {
       int choices[],
       unsigned int used_ordered,
       const int split_order[],
-      int points,
+      SumNode** leaf,
       EvalNodeArena& arena
   );
 

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -181,7 +181,7 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
       // auto slot = word_node->bound_;
       if (slot == 0) {
         slot = word_lists_.size();
-        word_lists_.push_back({static_cast<uint32_t>(length), t->WordId()});
+        word_lists_.push_back({static_cast<uint32_t>(word_score), t->WordId()});
         // assert(slot < (1 << 24));
         word_node->bound_ = slot & 0xffffff;
         assert(word_node->bound_ != 0);

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -180,7 +180,7 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
       if (slot == 0) {
         slot = word_lists_.size();
         word_lists_.push_back({t->WordId()});
-        assert(slot < (1 << 40));
+        assert(slot < (1 << 24));
         word_node->bound_ = slot & 0xffffff;
         // word_node->points_ = slot >> 24;
       } else {

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -174,15 +174,18 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
     assert(new_root == root_);
 
     if (dupe_mask_ > 0) {
-      assert(word_node->points_ == 0);
+      // assert(word_node->points_ == 0);
       auto slot = (word_node->points_ << 24) + word_node->bound_;
       // auto slot = word_node->bound_;
       if (slot == 0) {
         slot = word_lists_.size();
         word_lists_.push_back({t->WordId()});
-        assert(slot < (1 << 24));
+        // assert(slot < (1 << 24));
         word_node->bound_ = slot & 0xffffff;
-        // word_node->points_ = slot >> 24;
+        assert(slot >> 24 == 0);
+        word_node->points_ = slot >> 24;
+        auto reslot = (word_node->points_ << 24) + word_node->bound_;
+        assert(slot == reslot);
       } else {
         auto& word_list = word_lists_[slot];
         auto word_id = t->WordId();

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -98,6 +98,8 @@ const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena) {
     cout << i << "\t" << counts[i] << endl;
   }
 
+  root->SetPointsAndBound(word_lists_);
+
   // arena.PrintStats();
 
   // This can be used to investigate the layout of EvalNode.
@@ -164,7 +166,7 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
   }
 
   if (t->IsWord()) {
-    // auto word_score = kWordScores[length];
+    auto word_score = kWordScores[length];
     // auto is_dupe = (dupe_mask_ > 0) && CheckForDupe(t);
 
     SumNode* word_node;
@@ -179,9 +181,10 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
       // auto slot = word_node->bound_;
       if (slot == 0) {
         slot = word_lists_.size();
-        word_lists_.push_back({t->WordId()});
+        word_lists_.push_back({static_cast<uint32_t>(length), t->WordId()});
         // assert(slot < (1 << 24));
         word_node->bound_ = slot & 0xffffff;
+        assert(word_node->bound_ != 0);
         assert(slot >> 24 == 0);
         word_node->points_ = slot >> 24;
         auto reslot = (word_node->points_ << 24) + word_node->bound_;
@@ -195,6 +198,8 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
           num_dupes_ += 1;
         }
       }
+    } else {
+      word_node->points_ += word_score;
     }
   }
 }

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -174,12 +174,15 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
     assert(new_root == root_);
 
     if (dupe_mask_ > 0) {
-      auto slot = word_node->bound_;
+      assert(word_node->points_ == 0);
+      auto slot = (word_node->points_ << 24) + word_node->bound_;
+      // auto slot = word_node->bound_;
       if (slot == 0) {
         slot = word_lists_.size();
         word_lists_.push_back({t->WordId()});
-        assert(slot < (1 << 23));
-        word_node->bound_ = slot;
+        assert(slot < (1 << 40));
+        word_node->bound_ = slot & 0xffffff;
+        // word_node->points_ = slot >> 24;
       } else {
         auto& word_list = word_lists_[slot];
         auto word_id = t->WordId();

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -178,6 +178,7 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
     if (dupe_mask_ > 0) {
       auto slot = word_node->bound_;
       if (slot == 0) {
+        // Fresh find!
         word_node->points_ = word_score;
         word_node->bound_ = t->WordId() | (1 << 23);
       } else if (slot & (1 << 23)) {
@@ -191,7 +192,7 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
           assert(slot < (1 << 23));
           word_node->bound_ = slot;
         } else {
-          // it's a duplicate
+          num_dupes_ += 1;
         }
       } else {
         // there are already 2+ words on this node; maybe there should be a third.
@@ -200,7 +201,7 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
         if (find(word_list.begin(), word_list.end(), word_id) == word_list.end()) {
           word_list.push_back(word_id);
         } else {
-          // num_dupes_ += 1;
+          num_dupes_ += 1;
         }
       }
     } else {

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -42,6 +42,7 @@ class OrderlyTreeBuilder : public BoardClassBoggler<M, N> {
   int letter_counts_[26];  // TODO: don't need the count here, a 52-bit mask would work
   uint32_t dupe_mask_;
   vector<unordered_set<uint64_t>*> found_words_;
+  vector<vector<uint32_t>> word_lists_;
   unsigned int num_overflow_;
 
   void DoAllDescents(int cell, int n, int length, Trie* t, EvalNodeArena& arena);
@@ -56,6 +57,7 @@ const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena) {
   root_ = arena.NewRootNodeWithCapacity(M * N);  // this will never be reallocated
   used_ = 0;
 
+  word_lists_.reserve(1000);
   found_words_.reserve(1000);
   for (int i = 0; i < 26; i++) {
     letter_counts_[i] = 0;
@@ -149,10 +151,13 @@ void OrderlyTreeBuilder<M, N>::DoDFS(
     auto is_dupe = (dupe_mask_ > 0) && CheckForDupe(t);
 
     if (!is_dupe) {
+      SumNode* word_node;
       auto new_root = root_->AddWordWork(
-          choices_, used_ordered_, BucketBoggler<M, N>::SPLIT_ORDER, word_score, arena
+          choices_, used_ordered_, BucketBoggler<M, N>::SPLIT_ORDER, &word_node, arena
       );
       assert(new_root == root_);
+      word_node->points_ += word_score;
+      word_node->bound_ += word_score;
     }
   }
 }


### PR DESCRIPTION
Fixes #136 

Still some work to do, but this seems like a much better way to de-duplicate. In practice the vast, vast majority of SumNodes correspond to paths that either 1) don't have a repeated letter or 2) only have one word. This means that we can store the first word inline in the `bound_` field and only allocate additional storage in the rare case that there are 2+ distinct words.

Some stats:

```
$ poetry run python -m boggle.orderly_tree_builder "bcdfgmpqvwxz aeijou hklnrsty hklnrsty hklnrsty aeijou hklnrsty bcdfgmpqvwxz hklnrsty aeijou hklnrsty aeijou hklnrsty aeijou hklnrsty hklnrsty"
Number of words found: 13460449
1	13284177
2	162937
3	11273
4	1713
5	312
6	36
```

So 98.7% of the SumNodes only have one word associated with them.

Here's the new runtime / memory usage:

```
$ /usr/bin/time -l poetry run python -m boggle.orderly_tree_builder "bcdfgmpqvwxz aeijou hklnrsty hklnrsty hklnrsty aeijou hklnrsty bcdfgmpqvwxz hklnrsty aeijou hklnrsty aeijou hklnrsty aeijou hklnrsty hklnrsty"
7.47s OrderlyTreeBuilder: t.bound=36881, 67430812 nodes
        8.60 real         7.93 user         0.32 sys
          1704738816  maximum resident set size
```

Compare that with the numbers I recorded in #120:

```
# main
$ /usr/bin/time -l poetry run python -m boggle.orderly_tree_builder "bcdfgmpqvwxz aeijou hklnrsty hklnrsty hklnrsty aeijou hklnrsty bcdfgmpqvwxz hklnrsty aeijou hklnrsty aeijou hklnrsty aeijou hklnrsty hklnrsty"
6.81s OrderlyTreeBuilder: t.bound=53037, 67430812 nodes
        7.90 real         7.29 user         0.30 sys
          1686126592  maximum resident set size

# dedupe-multi
/usr/bin/time -l poetry run python -m boggle.orderly_tree_builder "bcdfgmpqvwxz aeijou hklnrsty hklnrsty hklnrsty aeijou hklnrsty bcdfgmpqvwxz hklnrsty aeijou hklnrsty aeijou hklnrsty aeijou hklnrsty hklnrsty"
8.68s OrderlyTreeBuilder: t.bound=36881, 67430812 nodes
        9.77 real         9.01 user         0.44 sys
          2317451264  maximum resident set size
```

So this claws back ~2/3 of the runtime slowdown from #120 and ~97% of the extra memory.