### PR TITLE
Fill in the last number

### DIFF
--- a/paper/README.md
+++ b/paper/README.md
@@ -617,7 +617,8 @@ Using a canonical order for the cells naturally synchronizes choices across subt
 | 3x4 (a) | 51,317 | 4,397 |
 | 3x4 (b) | 194,425 | 10,018 |
 | 4x4 | 514,182 | 53,037 |
-| 5x5 | 1,910,956 | … |
+| 5x5 | 1,910,956 | 433,505 |
+
 - 2x2 is `ab cd ef gh` from the [insights post](https://www.danvk.org/2025/02/21/orderly-boggle.html)
 - 3x3 is the 5M board class from earlier in the paper (containing the best board)
 - 3x4 (a) is board_id=27916 with three letter classes from [this sheet](https://docs.google.com/spreadsheets/d/1uG-KFJFdOS7MQcibcdloTtQEQAdwror6VA0BO0AhkYQ/edit?gid=1619399799#gid=1619399799)


### PR DESCRIPTION
#145 

Here's the deduped version:

```
$ /usr/bin/time -l poetry run python -m boggle.orderly_tree_builder "hklnrsty aeijou bcdfgmpqvwxz bcdfgmpqvwxz hklnrsty bcdfgmpqvwxz aeijou hklnrsty aeijou hklnrsty aeijou aeijou hklnrsty aeijou hklnrsty bcdfgmpqvwxz hklnrsty hklnrsty aeijou bcdfgmpqvwxz hklnrsty aeijou bcdfgmpqvwxz aeijou hklnrsty"
2122.76s OrderlyTreeBuilder: t.bound=392437, 1034237014 nodes
     2471.15 real       188.44 user       836.24 sys
          9043247104  maximum resident set size
           194451127  page reclaims
                 274  page faults
             5417714  voluntary context switches
             9926925  involuntary context switches
       3245311576441  instructions retired
       3264516500524  cycles elapsed
         22628571904  peak memory footprint
/usr/bin/time -l poetry run python -m boggle.orderly_tree_builder   188.44s user 836.25s system 41% cpu 41:11.09 total
```

This takes 40-50 minutes to compute and an enormous amount of RAM. Compare this to ibuckets, which takes less than a second.

```
$ time poetry run python -m boggle.ibucket_solver "hklnrsty aeijou bcdfgmpqvwxz bcdfgmpqvwxz hklnrsty bcdfgmpqvwxz aeijou hklnrsty aeijou hklnrsty aeijou aeijou hklnrsty aeijou hklnrsty bcdfgmpqvwxz hklnrsty hklnrsty aeijou bcdfgmpqvwxz hklnrsty aeijou bcdfgmpqvwxz aeijou hklnrsty"
0.62s 669090 (max=1910956, sum=669090) hklnrsty aeijou bcdfgmpqvwxz bcdfgmpqvwxz hklnrsty bcdfgmpqvwxz aeijou hklnrsty aeijou hklnrsty aeijou aeijou hklnrsty aeijou hklnrsty bcdfgmpqvwxz hklnrsty hklnrsty aeijou bcdfgmpqvwxz hklnrsty aeijou bcdfgmpqvwxz aeijou hklnrsty
poetry run python -m boggle.ibucket_solver   0.83s user 0.07s system 77% cpu 1.170 total
```

It's interesting that the sum bound is better than max here. The orderly and deduped orderly bounds are slightly better, but not by much. The multiboggle problem is much worse on 5x5.