### PR TITLE
Use interned nodes during merging

### DIFF
--- a/cpp/arena.cc
+++ b/cpp/arena.cc
@@ -2,6 +2,16 @@
 
 #include "eval_node.h"
 
+EvalNodeArena::EvalNodeArena()
+    : num_nodes_(0), cur_buffer_(-1), tip_(EVAL_NODE_ARENA_BUFFER_SIZE) {
+  canonical_nodes_.resize(NUM_INTERNED);
+  for (int i = 0; i < NUM_INTERNED; i++) {
+    canonical_nodes_[i] = NewSumNodeWithCapacity(0);
+    canonical_nodes_[i]->points_ = i + 1;
+    canonical_nodes_[i]->bound_ = i + 1;
+  }
+}
+
 EvalNodeArena::~EvalNodeArena() {
   for (auto buffer : buffers_) {
     delete[] buffer;

--- a/cpp/arena.h
+++ b/cpp/arena.h
@@ -19,9 +19,11 @@ class SumNode;
 // Allocate this much memory at once.
 const uint64_t EVAL_NODE_ARENA_BUFFER_SIZE = 64 << 20;
 
+constexpr int NUM_INTERNED = 128;
+
 class EvalNodeArena {
  public:
-  EvalNodeArena() : num_nodes_(0), cur_buffer_(-1), tip_(EVAL_NODE_ARENA_BUFFER_SIZE) {}
+  EvalNodeArena();
   ~EvalNodeArena();
 
   uint64_t NumNodes() { return num_nodes_; }
@@ -36,6 +38,11 @@ class EvalNodeArena {
   SumNode* NewSumNodeWithCapacity(uint8_t capacity);
   ChoiceNode* NewChoiceNodeWithCapacity(uint8_t capacity);
 
+  SumNode* GetCanonicalNode(int points) {
+    assert(points >= 1 && points <= NUM_INTERNED);
+    return canonical_nodes_[points - 1];
+  }
+
   // For testing
   SumNode* NewRootNodeWithCapacity(uint8_t capacity);
   void PrintStats();
@@ -47,6 +54,7 @@ class EvalNodeArena {
   int cur_buffer_;
   int tip_;
   vector<pair<int, int>> watermarks_;
+  vector<SumNode*> canonical_nodes_;
 };
 
 unique_ptr<EvalNodeArena> create_eval_node_arena();

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -160,11 +160,6 @@ PYBIND11_MODULE(cpp_boggle, m) {
       .def("save_level", &EvalNodeArena::SaveLevel)
       .def("reset_level", &EvalNodeArena::ResetLevel)
       .def("num_nodes", &EvalNodeArena::NumNodes)
-      .def(
-          "get_canonical_node",
-          &EvalNodeArena::GetCanonicalNode,
-          py::return_value_policy::reference
-      )
       .def("bytes_allocated", &EvalNodeArena::BytesAllocated);
 
   py::class_<Symmetry>(m, "Symmetry")

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -160,6 +160,11 @@ PYBIND11_MODULE(cpp_boggle, m) {
       .def("save_level", &EvalNodeArena::SaveLevel)
       .def("reset_level", &EvalNodeArena::ResetLevel)
       .def("num_nodes", &EvalNodeArena::NumNodes)
+      .def(
+          "get_canonical_node",
+          &EvalNodeArena::GetCanonicalNode,
+          py::return_value_policy::reference
+      )
       .def("bytes_allocated", &EvalNodeArena::BytesAllocated);
 
   py::class_<Symmetry>(m, "Symmetry")

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -360,10 +360,14 @@ SumNode* merge_orderly_tree_children(
       ++it_b;
     }
   }
+  auto new_points = a->points_ + b_points;
   num_children += (a_end - it_a) + (b_end - it_b);
+  if (num_children == 0 && new_points >= 1 && new_points <= NUM_INTERNED) {
+    return arena.GetCanonicalNode(new_points);
+  }
 
   auto n = arena.NewSumNodeWithCapacity(num_children);
-  n->points_ = a->points_ + b_points;
+  n->points_ = new_points;
   n->bound_ = n->points_;
 
   it_a = &a->children_[0];

--- a/testdata/3x4-2520743-1400.txt
+++ b/testdata/3x4-2520743-1400.txt
@@ -56,7 +56,7 @@ Found unbreakable board for 2520743: perslitesand
   ],
   "boards_to_test": 2084,
   "init_nodes": 1426884,
-  "total_nodes": 2689169,
+  "total_nodes": 2568019,
   "tree_bytes": 67108864,
   "n_paths": 787201,
   "n_paths_uniq": 665026,


### PR DESCRIPTION
Potentially saves some memory and reduces churn. Has a small but positive effect on 705707:

```
/usr/bin/time -l poetry run python -m boggle.break_all 'aeijou bcdfgmpqvwxz hklnrsty, corner:aeiosuy bcdfghjklmnpqrtvwxz' 3500 --size 44 --board_id 705707 --switchover_score 6000 --log_per_board_stats
```

- Elapsed time: 738.36s → 711.34s (3.7% faster)
- Total nodes: 6948003435 → 5943452095 (-14.5%)
- Total bytes: 3154116608 → 3154116608 (no change)

The last number didn't change because the reduced number of nodes never meant the difference between having to allocate an extra 64MB chunk in the arena.