### PR TITLE
Full DAG for initial tree

### DIFF
--- a/boggle/breaker.py
+++ b/boggle/breaker.py
@@ -76,6 +76,8 @@ class HybridBreakDetails(BreakDetails):
     """Number of bytes used by the initial orderly tree"""
     n_paths: int
     n_paths_uniq: int
+    n_choice: int
+    n_sum: int
     tree_secs: list[float]
     total_bytes: int
     """Max bytes ever used while breaking"""
@@ -154,6 +156,8 @@ class HybridTreeBreaker:
             n_force=0,
             n_paths=0,
             n_paths_uniq=0,
+            n_choice=0,
+            n_sum=0,
             max_multi=0,
             bound_secs=defaultdict(float),
             test_secs=0.0,
@@ -167,6 +171,8 @@ class HybridTreeBreaker:
         self.details_.tree_secs = [ts.collect_s, ts.sort_s, ts.build_s]
         self.details_.n_paths = ts.n_paths
         self.details_.n_paths_uniq = ts.n_uniq
+        self.details_.n_sum = ts.n_sum
+        self.details_.n_choice = ts.n_choice
         num_nodes = arena.num_nodes()
         if self.log_breaker_progress:
             print(f"root {tree.bound=}, {num_nodes} nodes")

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -40,6 +40,8 @@ class TreeBuilderStats:
     build_s: float
     n_paths: int
     n_uniq: int
+    n_sum: int
+    n_choice: int
 
 
 class OrderlyTreeBuilder(BoardClassBoggler):
@@ -59,7 +61,9 @@ class OrderlyTreeBuilder(BoardClassBoggler):
         self.stats_ = None
 
     def build_tree(self, arena: PyArena = None):
-        stats = TreeBuilderStats(collect_s=0, sort_s=0, build_s=0, n_paths=0, n_uniq=0)
+        stats = TreeBuilderStats(
+            collect_s=0, sort_s=0, build_s=0, n_paths=0, n_uniq=0, n_sum=0, n_choice=0
+        )
         self.used_ = 0
         self.used_ordered_ = 0
         self.num_letters = [len(cell) for cell in self.bd_]

--- a/boggle/orderly_tree_builder.py
+++ b/boggle/orderly_tree_builder.py
@@ -293,6 +293,9 @@ def main():
     # print_word_list(trie, otb.words_)
     print(f"arena nodes: {o_arena.num_nodes()}")
     print(f"arena bytes: {o_arena.bytes_allocated()}")
+    ts = otb.get_stats()
+    print(f"build times: {[ts.collect_s, ts.sort_s, ts.build_s]}")
+    print(f"{ts.n_paths=} {ts.n_uniq=}")
 
     if isinstance(orderly_tree, SumNode):
         with open("tree.dot", "w") as out:

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -107,13 +107,12 @@ def test_orderly_bound22(is_python):
     assert failures == [(8, "adeg"), (7, "adeh")]
 
 
-@pytest.mark.parametrize("make_trie, get_tree_builder", OTB_PARAMS)
-def test_orderly_bound22_best(make_trie, get_tree_builder):
-    trie = make_trie("testdata/boggle-words-4.txt")
+@pytest.mark.parametrize("is_python", [True, False])
+def test_orderly_bound22_best(is_python):
+    _, otb = get_trie_otb("testdata/boggle-words-4.txt", (2, 2), is_python)
     board = "st ea ea tr"
     cells = board.split(" ")
     # num_letters = [len(cell) for cell in cells]
-    otb = get_tree_builder(trie, dims=(2, 2))
     otb.parse_board(board)
     arena = otb.create_arena()
     t = otb.build_tree(arena)
@@ -136,6 +135,26 @@ def test_orderly_bound22_best(make_trie, get_tree_builder):
     )
 
     # TODO: confirm these via ibuckets
+
+
+def test_equal_hash():
+    _, otb = get_trie_otb("testdata/boggle-words-4.txt", (2, 2), is_python=False)
+    board = "st ea ea tr"
+    # num_letters = [len(cell) for cell in cells]
+    otb.parse_board(board)
+    arena = otb.create_arena()
+    t = otb.build_tree(arena)
+
+    # These will vary from run to run since they're pointer hashes.
+    assert t.hash() == snapshot(3093267779)
+    assert t.is_equal(t)
+    choices = t.get_children()
+    assert len(choices) == 2
+    assert choices[0].hash() == snapshot(261416306)
+    assert choices[1].hash() == snapshot(1056468844)
+    assert choices[0].is_equal(choices[0])
+    assert choices[1].is_equal(choices[1])
+    assert not choices[0].is_equal(choices[1])
 
 
 # TODO: test C++ equivalence

--- a/boggle/orderly_tree_test.py
+++ b/boggle/orderly_tree_test.py
@@ -145,16 +145,30 @@ def test_equal_hash():
     arena = otb.create_arena()
     t = otb.build_tree(arena)
 
-    # These will vary from run to run since they're pointer hashes.
-    assert t.hash() == snapshot(3093267779)
+    # Actual values will vary from run to run since they're pointer hashes.
+    assert t.hash() == t.hash()
     assert t.is_equal(t)
     choices = t.get_children()
     assert len(choices) == 2
-    assert choices[0].hash() == snapshot(261416306)
-    assert choices[1].hash() == snapshot(1056468844)
+    # assert choices[0].hash() == snapshot(261416306)
+    # assert choices[1].hash() == snapshot(1056468844)
     assert choices[0].is_equal(choices[0])
     assert choices[1].is_equal(choices[1])
     assert not choices[0].is_equal(choices[1])
+    assert choices[0].hash() == choices[0].hash()
+    assert choices[1].hash() == choices[1].hash()
+    assert choices[0].hash() != choices[1].hash()
+    sums = choices[0].get_children()
+    assert len(sums) == 2
+    assert not sums[0].is_equal(t)
+    assert not sums[1].is_equal(t)
+    assert not sums[1].is_equal(sums[0])
+    assert sums[0].is_equal(sums[0])
+    assert sums[0].hash() != t.hash()
+    assert sums[1].hash() != t.hash()
+    assert sums[1].hash() != sums[0].hash()
+    assert sums[0].hash() == sums[0].hash()
+    assert sums[1].hash() == sums[1].hash()
 
 
 # TODO: test C++ equivalence

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -114,6 +114,8 @@ PYBIND11_MODULE(cpp_boggle, m) {
       .def_readwrite("collect_s", &TreeBuilderStats::collect_s)
       .def_readwrite("sort_s", &TreeBuilderStats::sort_s)
       .def_readwrite("build_s", &TreeBuilderStats::build_s)
+      .def_readwrite("n_sum", &TreeBuilderStats::n_sum)
+      .def_readwrite("n_choice", &TreeBuilderStats::n_choice)
       .def_readwrite("n_paths", &TreeBuilderStats::n_paths)
       .def_readwrite("n_uniq", &TreeBuilderStats::n_uniq);
 

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -133,6 +133,8 @@ PYBIND11_MODULE(cpp_boggle, m) {
       )
       .def("get_children", &SumNode::GetChildren, py::return_value_policy::reference)
       .def("score_with_forces", &SumNode::ScoreWithForces)
+      .def("is_equal", &SumNode::IsEqual)
+      .def("hash", &SumNode::Hash)
       .def("orderly_bound", &SumNode::OrderlyBound);
 
   py::class_<ChoiceNode>(m, "ChoiceNode")
@@ -145,6 +147,8 @@ PYBIND11_MODULE(cpp_boggle, m) {
           &ChoiceNode::GetChildForLetter,
           py::return_value_policy::reference
       )
+      .def("is_equal", &ChoiceNode::IsEqual)
+      .def("hash", &ChoiceNode::Hash)
       .def(
           "get_children", &ChoiceNode::GetChildren, py::return_value_policy::reference
       );

--- a/cpp/cpp_boggle.cc
+++ b/cpp/cpp_boggle.cc
@@ -135,6 +135,7 @@ PYBIND11_MODULE(cpp_boggle, m) {
       .def("score_with_forces", &SumNode::ScoreWithForces)
       .def("is_equal", &SumNode::IsEqual)
       .def("hash", &SumNode::Hash)
+      .def("copy_from", &SumNode::CopyFrom)
       .def("orderly_bound", &SumNode::OrderlyBound);
 
   py::class_<ChoiceNode>(m, "ChoiceNode")
@@ -149,6 +150,7 @@ PYBIND11_MODULE(cpp_boggle, m) {
       )
       .def("is_equal", &ChoiceNode::IsEqual)
       .def("hash", &ChoiceNode::Hash)
+      .def("copy_from", &ChoiceNode::CopyFrom)
       .def(
           "get_children", &ChoiceNode::GetChildren, py::return_value_policy::reference
       );

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -16,15 +16,20 @@ inline bool SortByCell(const ChoiceNode* a, const ChoiceNode* b) {
   return a->cell_ < b->cell_;
 }
 
-void SumNode::CopyFrom(SumNode& other) {
-  points_ = other.points_;
-  bound_ = other.bound_;
+void SumNode::CopyFrom(const SumNode* other) {
+  int num_bytes =
+      sizeof(SumNode) + other->num_children_ * sizeof(SumNode::children_[0]);
+  const void* src = other;
+  void* dst = this;
+  memcpy(dst, src, num_bytes);
 }
 
-void ChoiceNode::CopyFrom(ChoiceNode& other) {
-  cell_ = other.cell_;
-  bound_ = other.bound_;
-  child_letters_ = other.child_letters_;
+void ChoiceNode::CopyFrom(const ChoiceNode* other) {
+  int num_bytes =
+      sizeof(ChoiceNode) + other->NumChildren() * sizeof(ChoiceNode::children_[0]);
+  const void* src = other;
+  void* dst = this;
+  memcpy(dst, src, num_bytes);
 }
 
 SumNode* ChoiceNode::GetChildForLetter(int letter) const {

--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -520,3 +520,64 @@ void ChoiceNode::SetBoundsForTesting() {
     bound_ = max(bound_, c->bound_);
   }
 }
+
+// Borrowed from Boost.ContainerHash via https://stackoverflow.com/a/78509978/388951
+void hash_combine(uint32_t& seed, const uint32_t& v) {
+  uint32_t x = seed + 0x9e3779b9 + std::hash<uint32_t>()(v);
+  const uint32_t m1 = 0x21f0aaad;
+  const uint32_t m2 = 0x735a2d97;
+  x ^= x >> 16;
+  x *= m1;
+  x ^= x >> 15;
+  x *= m2;
+  x ^= x >> 15;
+  seed = x;
+}
+
+inline uint32_t pointer_hash(void* p) { return std::hash<uintptr_t>()((uintptr_t)p); }
+
+uint32_t SumNode::Hash() const {
+  uint32_t hash = points_;
+  hash_combine(hash, num_children_);
+  for (int i = 0; i < num_children_; i++) {
+    hash_combine(hash, pointer_hash(children_[i]));
+  }
+  return hash;
+}
+
+bool SumNode::IsEqual(const SumNode& other) const {
+  if (bound_ != other.bound_ || points_ != other.points_ ||
+      num_children_ != other.num_children_) {
+    return false;
+  }
+  for (int i = 0; i < num_children_; i++) {
+    if (children_[i] != other.children_[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+uint32_t ChoiceNode::Hash() const {
+  uint32_t hash = cell_;
+  hash_combine(hash, child_letters_);
+  int num_children = NumChildren();
+  for (int i = 0; i < num_children; i++) {
+    hash_combine(hash, pointer_hash(children_[i]));
+  }
+  return hash;
+}
+
+bool ChoiceNode::IsEqual(const ChoiceNode& other) const {
+  if (bound_ != other.bound_ || cell_ != other.cell_ ||
+      child_letters_ != other.child_letters_) {
+    return false;
+  }
+  int num_children = NumChildren();
+  for (int i = 0; i < num_children; i++) {
+    if (children_[i] != other.children_[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -55,6 +55,10 @@ class SumNode {
   vector<ChoiceNode*> GetChildren();
   void SetBoundsForTesting();
 
+  // Shallow hash and equality test based on child pointers
+  uint32_t Hash() const;
+  bool IsEqual(const SumNode& other) const;
+
  private:
 };
 
@@ -88,6 +92,10 @@ class ChoiceNode {
   // Find child SumNode for given letter using popcount on child_letters_ bitmask
   SumNode* GetChildForLetter(int letter) const;
   void SetBoundsForTesting();
+
+  // Shallow hash and equality test based on child pointers
+  uint32_t Hash() const;
+  bool IsEqual(const ChoiceNode& other) const;
 
  private:
 };

--- a/cpp/eval_node.h
+++ b/cpp/eval_node.h
@@ -30,8 +30,7 @@ class SumNode {
 
   void PrintJSON() const;
 
-  // Shallow copy -- excludes children
-  void CopyFrom(SumNode& other);
+  void CopyFrom(const SumNode* other);
 
   // Must have forces.size() == M * N; set forces[i] = -1 to not force a cell.
   unsigned int ScoreWithForces(const vector<int>& forces) const;
@@ -80,8 +79,7 @@ class ChoiceNode {
 
   void PrintJSON() const;
 
-  // Shallow copy -- excludes children
-  void CopyFrom(ChoiceNode& other);
+  void CopyFrom(const ChoiceNode* other);
 
   unsigned int ScoreWithForces(const vector<int>& forces) const;
 

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -140,8 +140,11 @@ const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena) {
   duration = chrono::duration_cast<chrono::milliseconds>(end4 - end3).count();
   stats.build_s = duration / 1000.0;
 
+  // release memory ASAP
   words_.clear();
-  words_.shrink_to_fit();  // release memory ASAP
+  words_.shrink_to_fit();
+  sum_cache_.clear();
+  choice_cache_.clear();
   stats_ = stats;
 
   // arena.PrintStats();

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -18,6 +18,8 @@ struct TreeBuilderStats {
   float build_s;
   uint32_t n_paths;
   uint32_t n_uniq;
+  uint32_t n_sum;
+  uint32_t n_choice;
 };
 
 template <int M, int N>
@@ -141,6 +143,8 @@ const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena) {
   auto end4 = chrono::high_resolution_clock::now();
   duration = chrono::duration_cast<chrono::milliseconds>(end4 - end3).count();
   stats.build_s = duration / 1000.0;
+  stats.n_sum = sum_cache_.size();
+  stats.n_choice = choice_cache_.size();
 
   // release memory ASAP
   words_.clear();

--- a/cpp/orderly_tree_builder.h
+++ b/cpp/orderly_tree_builder.h
@@ -134,6 +134,8 @@ const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena) {
   stats.n_uniq = words_.size();
   // PrintWordList();
 
+  sum_cache_.reserve(words_.size() / 5);
+  choice_cache_.reserve(words_.size() / 5);
   auto root = RangeToSumNode(words_, {0, words_.size()}, 0, arena);
 
   auto end4 = chrono::high_resolution_clock::now();
@@ -164,10 +166,10 @@ const SumNode* OrderlyTreeBuilder<M, N>::BuildTree(EvalNodeArena& arena) {
   cout << "root->children_: " << (uintptr_t)&root->children_ - r << endl;
   */
 
-  cout << "sum_cache.size() = " << sum_cache_.size() << " hit=" << sum_hit_
-       << " miss=" << sum_miss_ << endl;
-  cout << "choice_cache.size() = " << choice_cache_.size() << " hit=" << choice_hit_
-       << " miss=" << choice_miss_ << endl;
+  // cout << "sum_cache.size() = " << sum_cache_.size() << " hit=" << sum_hit_
+  //      << " miss=" << sum_miss_ << endl;
+  // cout << "choice_cache.size() = " << choice_cache_.size() << " hit=" << choice_hit_
+  //      << " miss=" << choice_miss_ << endl;
 
   return root;
 }


### PR DESCRIPTION
This has a pretty dramatic effect on memory usage for the initial tree:

- Arena nodes: 113,017,781 → 10,475,032
- Arena bytes: 1.94G → 320M

Total RAM allocation during breaking is down 50%, but this translates into literally zero improvement in breaking time. This is pretty surprising to me! I wonder if it's more of a win on Intel, or when you're running 100 threads and memory contention is more of an issue.