### PR TITLE
Add assertion to OrderlyBound advance

### DIFF
--- a/cpp/eval_node.cc
+++ b/cpp/eval_node.cc
@@ -196,7 +196,9 @@ inline uint16_t advance(
 ) {
   for (int i = 0; i < node->num_children_; i++) {
     auto child = node->children_[i];
-    stacks[child->cell_][stack_sizes[child->cell_]++] = child;
+    auto n = stack_sizes[child->cell_]++;
+    assert(n < MAX_STACK_DEPTH);
+    stacks[child->cell_][n] = child;
     sums[child->cell_] += child->bound_;
   }
   return node->points_;


### PR DESCRIPTION
The max stack size comes from https://github.com/danvk/hybrid-boggle/commit/ca54147e67e023d05d4bbb71bbbe27c35d668686; it's not clear to me why 25*26 would be a strict limit on the stack size, hence the assertion.